### PR TITLE
Add new labeling rules and change val_split strategy

### DIFF
--- a/coin_chj.ipynb
+++ b/coin_chj.ipynb
@@ -1,0 +1,1234 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e1f647d3-4eca-4515-9a59-d6e288b85a24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import pyupbit\n",
+    "import psycopg2\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "\n",
+    "import lightgbm as lgb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6984ea4-db7b-40dc-bc22-1d0bfd0434e0",
+   "metadata": {},
+   "source": [
+    "## Load Dataset\n",
+    "-----------------"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8c0bffc9-d074-4355-94f3-340efaa04176",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # Get data using upbit api\n",
+    "# df = pyupbit.get_ohlcv(\"KRW-ETH\", interval=\"minute1\", count=106200)\n",
+    "# df.rename_axis(\"datetime\", inplace=True)\n",
+    "# df.to_csv(\"krw_eth_upbit.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "353da742-28ac-47e3-9b6e-0732e85a740a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # Get data from imhs db\n",
+    "# t_host = \"better-korea.postgres.database.azure.com\"\n",
+    "# t_dbname = \"investing\"\n",
+    "# t_user = \"testid\"\n",
+    "# t_passwsrd = \"6Ja2s0V6kop4SBIl\"\n",
+    "# t_port = 5432\n",
+    "\n",
+    "# connection = psycopg2.connect(host=t_host, dbname=t_dbname, user=t_user, password=t_passwsrd, port=t_port)\n",
+    "# cursor = connection.cursor()\n",
+    "# sql = \"\"\"\n",
+    "#     SELECT *\n",
+    "#     FROM coin_candles\n",
+    "# \"\"\"\n",
+    "# cursor.execute(sql)\n",
+    "# df = pd.DataFrame(cursor.fetchall(), columns = [\"market\", \"datetime\", \"open\", \"high\", \"low\", \"close\", \"volume\", \"value\"])\n",
+    "# df.set_index(\"datetime\", inplace=True)\n",
+    "# df.to_csv(\"krw_eth_imhsdb.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6e85473d-65dd-47e2-be8c-86c9fe0c047e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get data from a saved file\n",
+    "df = pd.read_csv(\"krw_eth_upbit.csv\", index_col=\"datetime\")\n",
+    "# df = pd.read_csv(\"krw_eth_imhsdb.csv\", index_col=\"datetime\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b77979cb-2bb0-454d-ae9c-74ee73326f73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df1 = pd.read_csv(\"krw_eth_upbit.csv\", index_col=\"datetime\")\n",
+    "# df1 = df1.add_prefix(\"api_\")\n",
+    "# df2 = pd.read_csv(\"krw_eth_imhsdb.csv\", index_col=\"datetime\")\n",
+    "# df3 = df2.join(df1, how=\"left\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7e16b58-8440-4c1b-a82f-97f8e8affb2c",
+   "metadata": {},
+   "source": [
+    "## Generate Features\n",
+    "---------------"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "955ae13b-baba-494a-a230-54fb11008d72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_stochastic_fast_k(close_price, low, high, n=5):\n",
+    "    fast_k = ((close_price - low.rolling(n).min()) / (high.rolling(n).max() - low.rolling(n).min())) * 100\n",
+    "    return fast_k\n",
+    "\n",
+    "# Slow %K = Fast %K의 m기간 이동평균(SMA)\n",
+    "def get_stochastic_slow_k(fast_k, n=3):\n",
+    "    slow_k = fast_k.rolling(n).mean()\n",
+    "    return slow_k\n",
+    "\n",
+    "# Slow %D = Slow %K의 t기간 이동평균(SMA)\n",
+    "def get_stochastic_slow_d(slow_k, n=3):\n",
+    "    slow_d = slow_k.rolling(n).mean()\n",
+    "    return slow_d\n",
+    "\n",
+    "def get_macd(price, slow, fast, smooth):\n",
+    "    exp1 = price.ewm(span = fast, adjust = False).mean()\n",
+    "    exp2 = price.ewm(span = slow, adjust = False).mean()\n",
+    "    macd = pd.DataFrame(exp1 - exp2).rename(columns = {'close':'macd'})\n",
+    "    signal = pd.DataFrame(macd.ewm(span = smooth, adjust = False).mean()).rename(columns = {'macd':'signal'})\n",
+    "    hist = pd.DataFrame(macd['macd'] - signal['signal']).rename(columns = {0:'hist'})\n",
+    "    frames =  [macd, signal, hist]\n",
+    "    df = pd.concat(frames, join = 'inner', axis = 1)\n",
+    "    return df\n",
+    "\n",
+    "def get_rsi(price, period=14):\n",
+    "    delta = price.diff()\n",
+    "    gains, declines = delta.copy(), delta.copy()\n",
+    "    gains[gains < 0] = 0\n",
+    "    declines[declines > 0] = 0\n",
+    "    \n",
+    "    _gain = gains.ewm(com=(period-1), min_periods=period).mean()\n",
+    "    _loss = declines.abs().ewm(com=(period-1), min_periods=period).mean()\n",
+    "    RS = _gain / _loss\n",
+    "    \n",
+    "    return pd.Series(100 - (100/(1+RS)), name = 'RSI')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8437b745-a4d0-411e-bc72-77bbdf43ad46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ft = df[[\"open\", \"high\", \"low\", \"close\", \"volume\", \"value\"]].copy()\n",
+    "\n",
+    "## MA: 이동평균선\n",
+    "ft['MA5'] = ft['close'].rolling(window=5).mean()\n",
+    "ft['MA20'] = ft['close'].rolling(window=20).mean()\n",
+    "ft['MA60'] = ft['close'].rolling(window=60).mean()\n",
+    "# ft['MA200'] = ft['Close'].rolling(window=200).mean()\n",
+    "\n",
+    "ft['stddev'] = ft['close'].rolling(window=20).std() # 20일 이동표준편차\n",
+    "ft['upper'] = ft['MA20'] + 2*ft['stddev'] # 상단밴드\n",
+    "ft['lower'] = ft['MA20'] - 2*ft['stddev'] # 하단밴드\n",
+    "ft['upper-lower'] = ft['upper']-ft['lower']\n",
+    "\n",
+    "ft['MA20-MA5'] = ft['MA20'] - ft['MA5']\n",
+    "ft['MA60-MA20'] = ft['MA60'] - ft['MA20']\n",
+    "\n",
+    "# MACD\n",
+    "macd_short, macd_long, macd_signal=12,26,9 #기본값\n",
+    "ft[\"MACD_short\"]=ft['close'].ewm(span=macd_short).mean()\n",
+    "ft[\"MACD_long\"]=ft['close'].ewm(span=macd_long).mean()\n",
+    "ft[\"MACD\"]=ft.apply(lambda x: (x[\"MACD_short\"]-x[\"MACD_long\"]), axis=1)\n",
+    "ft[\"MACD_signal\"]=ft[\"MACD\"].ewm(span=macd_signal).mean()  \n",
+    "ft[\"MACD_oscillator\"]=ft.apply(lambda x:(x[\"MACD\"]-x[\"MACD_signal\"]), axis=1)\n",
+    "ft[\"MACD_sign\"]=ft.apply(lambda x: (\"매수\" if x[\"MACD\"]>x[\"MACD_signal\"] else \"매도\"), axis=1)\n",
+    "\n",
+    "# fast_k, slow_k, slow_d를 획득\n",
+    "ft['fast_k5'] = get_stochastic_fast_k(ft['close'], ft['low'], ft['high'], 5)\n",
+    "ft['slow_k3'] = get_stochastic_slow_k(ft['fast_k5'], 3)\n",
+    "ft['slow_d3'] = get_stochastic_slow_d(ft['slow_k3'], 3)\n",
+    "\n",
+    "ft['fast_k10'] = get_stochastic_fast_k(ft['close'], ft['low'], ft['high'], 10)\n",
+    "ft['slow_k6'] = get_stochastic_slow_k(ft['fast_k10'], 6)\n",
+    "ft['slow_d6'] = get_stochastic_slow_d(ft['slow_k6'], 6)\n",
+    "\n",
+    "ft['fast_k20'] = get_stochastic_fast_k(ft['close'], ft['low'], ft['high'], 20)\n",
+    "ft['slow_k12'] = get_stochastic_slow_k(ft['fast_k20'], 12)\n",
+    "ft['slow_d12'] = get_stochastic_slow_d(ft['slow_k12'], 12)\n",
+    "\n",
+    "# RSI\n",
+    "ft['rsi'] = get_rsi(ft['close'])\n",
+    "\n",
+    "#t-1의 값을 Feature로 사용하기 위함\n",
+    "features = [\n",
+    "    'close', 'open', 'high', 'low', 'volume', 'MA5', 'MA20', 'MA60', \n",
+    "    'MA60-MA20', 'MA20-MA5', 'MACD', 'MACD_oscillator', \n",
+    "    'MACD_signal', 'fast_k5', 'slow_k3', 'slow_d3', 'fast_k10', 'slow_k6', 'slow_d6', \n",
+    "    'fast_k20', 'slow_k12', 'slow_d12', 'rsi', 'upper', 'lower', 'stddev', 'upper-lower'\n",
+    "]\n",
+    "for feature in features:\n",
+    "    ft[feature+'-1']=ft[feature].shift(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "411b1261-c25d-4fe5-8398-08178225e20d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ft.dropna(inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bcd2d21-e1eb-48d9-b600-e20fedb30d45",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Make Labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c109b1dc-8ed3-44e3-90b1-ce7218eeec6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_th = 0.02 # target earning rate per trade\n",
+    "fee = 0.0005 # trade fee\n",
+    "max_window = 120 # minutes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f3bfdbd4-34f7-4945-b7f9-01c9d9311e2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# option1 - Hit the target after fixed window size\n",
+    "y1 = df[[\"close\"]].copy()\n",
+    "y1[\"close_t+20\"] = y1[\"close\"].shift(-20)\n",
+    "y1[\"close_t+60\"] = y1[\"close\"].shift(-60)\n",
+    "y1[\"close_t+120\"] = y1[\"close\"].shift(-120)\n",
+    "\n",
+    "y1['earn+20'] = ((1 + target_th) * y1['close'] < y1['close_t+20']).astype(int)\n",
+    "y1['earn+60'] = ((1 + target_th) * y1['close'] < y1['close_t+60']).astype(int)\n",
+    "y1['earn+120'] = ((1 + target_th) * y1['close'] < y1['close_t+120']).astype(int)\n",
+    "\n",
+    "y1[\"target\"] = y1[\"earn+120\"]\n",
+    "y1.dropna(inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cca11fe6-9caa-40ae-9612-a37dcca48ac9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option2 - Hit the target in max_window (=120)\n",
+    "y2 = df[[\"close\"]].copy()\n",
+    "y2.sort_index(inplace=True, ascending=False)\n",
+    "y2[\"max_in_wind\"] = y2.rolling(max_window, closed=\"left\").max()\n",
+    "y2[\"max_earn_in_wind\"] = y2[\"max_in_wind\"] / y2[\"close\"] - 1\n",
+    "y2[\"target\"] = (y2[\"max_earn_in_wind\"] >= target_th).astype(int)\n",
+    "y2.sort_index(inplace=True)\n",
+    "y2[\"clost_t+{}\".format(max_window)] = y2[\"close\"].shift(-max_window)\n",
+    "y2.dropna(inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "7df04e36-d61d-4474-b704-f4eb65b99787",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option3 - Multi Classification \n",
+    "y3 = df[[\"close\"]].copy()\n",
+    "\n",
+    "class_unit = 10 #minutes\n",
+    "for t in range(class_unit, max_window + class_unit, class_unit):\n",
+    "    y3[\"close_t+{}\".format(t)] = y3[\"close\"].shift(-t)\n",
+    "    y3[\"earn+{}\".format(t)] = ((y3[\"close_t+{}\".format(t)] / y3[\"close\"] - 1) > target_th).astype(int)\n",
+    "\n",
+    "selected_columns = [\"earn+{}\".format(t) for t in range(class_unit, max_window+class_unit, class_unit)]\n",
+    "target = y3[selected_columns].values.argmax(axis=1) + 1\n",
+    "target[y3[selected_columns].values.sum(axis=1) == 0] = 0\n",
+    "y3[\"target\"] = target\n",
+    "y3.dropna(inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe22fb9a-4544-4ec3-a887-0f8400894ba9",
+   "metadata": {},
+   "source": [
+    "## Train Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0d955477-457a-482e-ac7e-b5f5ec2616d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "selected_features = [\n",
+    "    'volume-1', 'MA20-MA5-1', 'MA60-MA20-1', 'MACD-1', 'MACD_oscillator-1', \n",
+    "    'MACD_signal-1', 'slow_k3-1', 'slow_d3-1', 'slow_k6-1', 'slow_d6-1', \n",
+    "    'slow_k12-1', 'slow_d12-1', 'rsi-1', 'upper-1', 'lower-1', 'stddev-1', 'upper-lower-1'\n",
+    "]\n",
+    "data1 = ft[selected_features].join(y1[[\"target\"]], how=\"inner\")\n",
+    "data2 = ft[selected_features].join(y2[[\"target\"]], how=\"inner\")\n",
+    "data3 = ft[selected_features].join(y3[[\"target\"]], how=\"inner\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6528dd65-8aa6-46a8-9897-bb48c10bbcb6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='datetime'>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABZgAAADQCAYAAACKngRiAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAABCVElEQVR4nO3debwldX3n//en7+1uUBBQ2vkpoJcYTIZffolLjzFmzDhZFP1NQEeSQIxRgiEmwWTGxNiJM8SgE6M+opiAIqISDYhsJi3d7ALN0jS9QDf0Si/QC03vG/Ry+977nT+qzu0651SdU+ec2uv1fDz60eeeU+fUt757fetb9TXnnAAAAAAAAAAA6NWUvAMAAAAAAAAAACgnBpgBAAAAAAAAAH1hgBkAAAAAAAAA0BcGmAEAAAAAAAAAfWGAGQAAAAAAAADQFwaYAQAAAAAAAAB9Gc5rx6eeeqobGRnJa/cAAAAAAAAAgBgWL1680zk3I+yz3AaYR0ZGtGjRorx2DwAAAAAAAACIwcyei/qMR2QAAAAAAAAAAPrCADMAAAAAAAAAoC9dB5jN7Dtmtt3Mno743Mzsn8xsrZktM7O3JB9MAAAAAAAAAEDRxJnBfJ2kczp8/l5JZ/n/LpH0jcGDBQAAAAAAAAAouq4DzM65eZJ2d9jkPEnfc57HJJ1sZq9JKoB1d8+KbRqZNUd/cdNSjcyao9/+5nytfuGAJOmWxZsnXwfdv2q7Hl23s+tvf+Xu1RqZNUe/8qX7NTHh2j7ftPugvjf/2YGPoZPn9x7SyKw5unv5C7r4uoUamTVHn/jBE7G++/iG3bp7+QsDh2Hxc3u8uL16vs676hE51x4XYVa9sF+3Lt488P7vfHqrbnx848C/k4fH1u/SvSu2Tf69fseLGpk1R998cF2OoUrOo+t26lM3L9U18/I7ni/duUq/+Pf36vDR8VT345zT+772kEZmzdGTm/Z23f6u5S9o0bOdmoZsfPeRDTrrM3M1MmuOnt97qO3zO57aql/+h59o0+6DTe8/sdEr92f+9ZzQ+i9o36Gjuur+tV236+apzft07UPrIz+fs2yrnti4Rzc+vlG/dfWjA+2rTJxz+sDXH9GlNyyZfO97859tS7Moj2/YrQuuma/563ZNvjfr1mUamTVHc5/aGvqdo+MT+qf7ntGh0XGNjU9oZNYcjcyao6372vNQ0M2LNmlk1hwdHB2LFbZe/f3clfrjf10cux2K68UjY/ryXav04pHBw/3dRzZoZNYcPbK2ez+jV0fGxnXOFfP0nq/O09HxicR/vyoa+XV8wDopK+v8vsGGnS/lHZTCu2HBxtTj6d4V27Rg/S5d+9B6PbFxT6zvPLFxj+Ys8+pT55zOvfJhffKmJzU6Fl1OkziP2LrPO0/4zsMbdHB0TO+/6hE9snanHlm7U2++/G7d+XR4HT+orfsO6W9+9JQ+86OntG3/4VT2EeW5XS9pZNYcXXzdQo31WA8+unanRmbN0ejYhA4cPjpZVyx/fl+s7y9+brfufDr+udWF1zymbzwQ3kf+wtyVk/v/wtyVsX8zzJGxcX3xzlXa3iEtnt6yT5++ZZnuX7V9oH31at6aHZPHOTJrjs65Yp6OjMXrsx8+Oq6f+V936CertnXf2Dcx4fSFO1bqUzcvnTx3Pjo+oX+4Y5U+f/uKfg+jFA4fHdfX7n1Go2MTGhuf0O9+6zGdc8U8rd1+QFv3HdL533hUI7Pm6NIbluj5vYd025LNGpk1R9sPHNbho+P6/O0rNH/dLp1zxTx9+NsLdGTM+72oc6xH1+3UO75wn1a9sD92GJ1z+o2vPDjZV/yrW5bqfV97SJK0ZtsBffqWZfrHu1frx0uf19IY51uD2vPSqN75pZ9oZNYc7ThwJNHfXv3CAf3C392tvQdHI7e5aeEmPbJ2pz53+wp95+ENie4/CdcveE4js+bEPudAd0k8g/k0SZsCf2/232tjZpeY2SIzW7Rjx44Edl19f/i9RZKkW5d4A5mPb9it2Uu3SJL+8uales8V89q+c9F1C/W731rQ9bf/6SdrJUkbdx/Ug8+0p8fvXvuYLvv35dp36Gjf4e/mHf/wE0nSJd9frPv8DsGPlz4f67u//c35uuT7iwcOwwe/4Q3kPP7sbi3dtDd2x/6cKx7SX9y8dOD9f/xfl2jWbU8N/Dt5uOCax/QxP49K0rlXPiJJ+sIdq/IKUqKuf2yjbl68WX8/N7/j+foD67Rt/xHdkdJJVMOWvYe0YqvXgXr/VY903f6Pvr9Y5189P9UwxfGFuat0dNwbZPn7kBOYP75+ibbsPaTf+WZzWP/nD5+UJDknPd9lUPHvZi/Xl+9arQfWDHbS8kffX6TPz4k+yfrTG5boA19/VLNue0oLn92jfQfTq3uLZMeBI3pi417d7g9e7D98VJf9+3Jd+K3HYn3/t785X4+t362PfOfxyfduXOh1S/7k+iWh37l18WZ95Z41uuK+Nbp35bETu493aVM+dcsySdKfxbwQ2qtr5q3XHU+/oJVb2y8eD+LGxzfqqvvX6eZFm7pv3MXf/dg7gf3Qtd37Gb1a88KLWvXCAa3edkDrdzAY2U0SF9mz0OhnffS7j3fZEn/zo6d07pUPp7qPj31vkX7nmsf0+TkrJ88zuvnA1x/Vn/oXARds2K1lm/fptiVbtGZbdF2VxHnEf/+6l3cuv32F/vHuNXpy01596NoF+tC1C7Tn4FF9+tZ0+s8PrN6hGxZs1PULNuqhZ5K/mNbJf/nyA5Kk+1Zt14+XxTsnavhdv17+tye3NE0W+OHCeHX/B78xXx//1/jnVvPX79IX7wzvI39z3vrQ1/14cPUOfeOBdbry/rWR2/y3f35YP1y0SRddt3CgffXq97/TXK+teuGA/uXRZ2N992v3PaMjYxP6g+vilUNJ2rznkL754HrdvHjz5LnzfSu36+oH1+naAg7gJemaeev11XvX6Hvzn9XCZ/fo0XW7tOqFA3r3V+fp4usWadFz3gWz25dt1QOrd+iTN3nn6f/zh09q5db9uvbhDbrwW49p1QsH9NAzO/WJG57QV+9do29F5M8/+v5iPb/vsM654qHYYdz54qie2f6iJOkf716jmxZt1oqt+7XrxSP68dLn9cNFm/TPP1mrT/zgCZ0X43xrUI8/u1ubdnvnORddl2wb/J4r5mnfoaO6pkP5/qtbl+lD1y7Qtx/eoMtvXxE6GShPn/mR9xTgz1X84kyWMl3kzzl3jXNupnNu5owZM7LcNbo4GjIDYXJwoxwTZBIzkfDMsTpJYnZckbgCZf5Do+nO5pso6WTBoSk2+XpLh07L/sPNebPTtq0a+Xp0bLD88Py+3mZBFSn/pan1KJ2fF/f3OCgx2sNMr8ZslcOj4zoUmLkSN40OHE63rkt6ZmojLvcfKnYdXZc8n5Re8nye9vr9yZ0Jz56qqrTrl6CdL0bPPIsS9+6CJM4jgnFxcLR9lmFad5MU5VSg0wzxTg4fHW86hrKf2xzx42HXS73n1zwcPhov3Q72cd4U1k7GnTFddo3+2pGxiaZ6aMJ5kxOi7DwwGloNNeqXwxHx109dHEyfA4EwTbh86pXgPtNqW/b0MCGmqHVR1cYw8pTEAPMWSWcE/j7dfw8AAAAAAAAAUGFJDDDPlvT75nm7pH3OuXTv5QYAAAAAAAAA5G642wZm9gNJ75J0qpltlvS3kqZKknPuaklzJb1P0lpJByVdlFZg4SnonQVA5dSprFX91vROi6bVKZ2LKO/4z3v/DUkv7FdGwSioep1UR6RoZ1WrA7I4mrSiLFj/lDFdShhkxETaxpNbHyLYj6lNWtXmQBFD1wFm59yFXT53kv40sRABABBTvx3I+nT6AABIR9ptaRkHd4siGHNEYzGRLNnJ5fnHbX/nkeLBi2U57L4kiJvkZLrIH8qJWURA9Zms+0Y1RQ1YH3QwASAZWfQqrOJdF9okYHCMZRRHUeu0qrclWWKAGZLCB1CMkgYAk6gSARQJ/TTkIcsL0uTx/hBt+cp6EK2og3ZJI1sjLdSZyWGAGQAA1FJNzskAAAAQoi4D9EAWGGAuIepAIBtNC05VvPdR1tvH4iZL+3PQUBRReS/NNArOiitK0S5KOPLEM0OrjTTtrIzx06nvUOpF/poWHC0f56rfb62rsFQtax8+Sa3ZvfkcTgqLuTRmrXZKiVyeA53BPqtQ1VThGIqCAWYAQOXRcUAUsgYAFBODpADKiuoLdcQAMwCARf46oIOYsRJkRZ7VBvSOclMvLPI3OLof1Ub/MhtFqCeKEIa0ZroX4dgGVYVjKAoGmNEVjR8AlGLcsxpybXPi7Zx2EUVQtjqJclMNnIgDyFPYnQ2d6qUitD1FCENaqnBsTLRKDgPMiEQHEkBVUJ+VT1ZJRtYAgGIyGu++EG2oIvI1UHwMMJdQGleJqnDlCUha8FYiykgxxU2W9sU/SNuiyDv++9l9GkEmG1IuUW9lzPJVLacu8o9ycK5l0dTcQlJPaS66FzZ7t6rlcBBti3tnFEfNC4Q27zSPZGLx5HhYKDM5DDADAAAAAAqFRf6A7igmBUW6oIYYYAYAAAAAAMgIsyYBVA0DzAAAdMQJAJrxGEAAQNqSmplKmwWgCIo6255F/pLDADO6Kmg9AACZYrGh6itqxxcIU7Yqidl61VCybAegYnrtq9HypKsKfeey9aeKjAHmEsqqg045Q901L9SQx/4r0GKnLWYUdVpog0GPfEXFflapUpRyVpRw5IlyiTorYx2Qdohzu7AbXHC0rHVRzn1YpCMsLeuSvp1mmbZVny6635+mpgXiWz/LIaFK2KzkgnhKDgPMAIDKo+NQIhmPJ5A1AKD4mGEGoEyCFw2pv1AXDDDDxyk2AAAAgGIIDtBwoRhlETevJpWny3j3A4BqYoAZAACgB8xEAQAAQFlwHQJZYIC5jKgcgEzkXdSanwGdbmhK+4zBBHTrcNEhS1fuM28K8pzKNPddlizcVOeVJdCIjTTtrGrRk8XxpJWnmp4Hn2PC9Ns3y71dTZhre1FfYUlbx2hpPebWC/95xUne6/fkoZd6qqjnm0wcSQ4DzOiqap0UoB+Ug2Lq/+Sr9+/Q98hIhkWt32JNdYAi6LTgEZCaQLajb1RcRR3IAQbVa852znXst6VVUlovmudRJqkHkDUGmOFrP0nJbeVmAG3SHkhgoAJFk2aObGre+thR2brrlG4AWUui3gmei4SdlnCqEq5q53DW9qLYso7+kkTLwILxmkz9ksCP5Pj7QBHFGmA2s3PMbLWZrTWzWSGfv87M7jezJ8xsmZm9L/mgAgAAAADqgEX+AAAoj64DzGY2JOkqSe+VdLakC83s7JbN/pekm5xzb5Z0gaSvJx1QAACAImBSCgAAGATXTABUTZwZzG+TtNY5t945NyrpRknntWzjJL3Cf32SpOeTCyJapdMY0cQBrfKeLZPl7qv+jK5OR5f1kfPMyma5R0fe+/flHg+FQCRUGanbWdXqgFIv8lfyhbroZ+Qr3ehv/3FSu11eRaAoC4RmqS7HiXiGY2xzmqRNgb83S/rFlm0+K+luM/uEpJdL+vVEQgcABUHbWUyxOzUDJCBpn4+s4r3qF1cAIC3UnukaZOCmdYExVBjp2zWP53HRpW2POaRT0cp+0cKD5CW1yN+Fkq5zzp0u6X2Svm9mbb9tZpeY2SIzW7Rjx46Edo20UQ8A1ccif92xWEdGiGcglrLVSSULLiLE7S8knd4s8gdAKucgZZXrqiofG3oXZ4B5i6QzAn+f7r8XdLGkmyTJOTdf0nGSTm39IefcNc65mc65mTNmzOgvxAAAACngtmIgPZQuDILqGUA/qDrSRd2MoDgDzAslnWVmZ5rZNHmL+M1u2WajpF+TJDP7j/IGmJmiXHJcjAIAVFGjM9zv4zGYrQEAKCqjkSoFBuZ6k3SunuwLkg5AYroOMDvnxiRdKukuSSsl3eScW25ml5vZuf5mfyHpD81sqaQfSPqoYxpQaohaICv5lrUsy3rVn0Pb6fiyrlOpwoulKOlR9TIYB88MrTjStKOq1QHlXuTPBV6ns480ca5YXWFJW7W6IwlxykAa12Ga6456pEs9jhJxxVnkT865uZLmtrx3WeD1Ckm/nGzQAKA4atJHKB2SBf1onFT0++xx6gMAoC4sMtIGOKZTcUhrwn/rPvMoksF91mXAux9ETXKSWuQPJUehAuqNRf6i0SEDgATQzNQKi/wNjt5HOWWdbnRTq18XJCGtbNJL1JNVq48BZgAAYqDzCqBIqJKQB9pCAECV0K4lhwFmdMVVUQBAZnJsc2jugBRRwDAAzkeKhbu7kJeenzldgKxa5eJS4UNDHxhgLqGsKiiu5KDu8u4MZLn7Oi8QkvmtjBnvr+iiylndmqC865siaHpWICUlVJkHdUjTzkqctKFKvchf0+uKJQwKpPe8FfaN2uTQHgYn8ooT11x51ELV2i4MhgFmAIiBE4xiijvYUsbOTxnDnKSsDr/m0QwAA6AGLSrX4S+garr1mfPoU7eeO+ZxgbjMF6WzRDQlhwFmAACL/KE4yIpAJdHO1AuL/AGAp8p1VZWPDb1jgBkAgA64qF1d3JkAACgsptUBqaOYZYcZ1dXHAHMJpVEsKepAu7zLRbANTnsgrM4DbXH7OknNvqNz1SyPvBdMyaZyVtGkKcth1SEtklS2WUN1bmeqJG62SyK1mx5nGvKDqT2DueR1UXuQS1ZZtHBtLwouxUyTZTkosm6HHCdOuKsmGVXIf2XrTxUZA8zoihMCAGVHLYYk0REFeleFk1AAHsrz4JKKw7qdq/cab4VY8K/C6pb/0BkDzOiAM2igIe9OAlfZw1W5S1PlYyu7vOuDXlF7AEhDnLpwkMEH6q7+mFrvlipZo9XC2l6gjizidRxFGATNu++Y9/6LjLhJDgPMAAAGsAEAqWLmf72wyB8AFEdag+ycQyKIAWYAAACgBJhlAwBAMy42AcXAAHMJcXIBZCPvxdiyvJ2rCLeOpalzWnY+9qSzQbVjund5t2lFyft5x0MRBMsp0VE95PHOqhY/pV7kL+J11vrdd8WyEgLC+ixVqzuSUITnLtclXXrpR9ckSmqNAWagDZdAgTJKveRSNcCX9kyZtH6fGT5VQ4Iie0ZFAqAC0q7KijKBAd3RrCWHAWagDY0BUBZNMwVS31naO2jZXV2mPpRQ2kmT2qw8slTFkKDIXq93GlDv5CPtaCdZB0fZSE7XuMzwDogegpD+PnPMY2U6jylRUAuPAWYAAAs0dMBVbQAYHHVpvbDI3+AqfngAKqCXc8ii1mnMNk8OA8wAAAAAAAAAgL4wwFxCXGEBspF3Scvydp2q1ysdl/jL/NEX2e6v6PKOjqKkR9XLYBzNC3oRH1VDknZWtTogkUX+uiyYld7jhMq9UlcJg4yYQstB9sEovLz6EMF6vC7lsGptFwbDADPQpqg3bwDoJK2SW5cOIoqDRf4AAHQ/gPSkv8gfWhEn1ccAM9CGqg/tGGQsvtSTKOPBObJcfbHIH6I0JyFXDJA9C4zKxKlTqHbyUfJJ2LXAzM9sOBce03W4gzHPGdXUO/XEADO6o3IAKo9F/gAeywAASWGRv2qjvURees155FQgO7EGmM3sHDNbbWZrzWxWxDa/bWYrzGy5md2QbDCRtrA+Ap02AAAAAHngXKQ/xFu+Mh/QrMlgP/l6MPXIJcjbcLcNzGxI0lWSfkPSZkkLzWy2c25FYJuzJP21pF92zu0xs1enFWDUpg0Bclenslb12/Q6pWXWR171uO5VnrOgnCtOh7tO9U2Uplu68wsGUkKadla1OiCLw8kizsqYLFXLSziGRf6S0xiwTrJfXstH09TlOBFLnBnMb5O01jm33jk3KulGSee1bPOHkq5yzu2RJOfc9mSDCWSJy6NAGVFyEVvBp8GwyB8A1HSwJgXU/ag68jhQDHEGmE+TtCnw92b/vaA3SnqjmT1iZo+Z2TlhP2Rml5jZIjNbtGPHjv5CDKSOHizaMeu0eFpnvqaVQnmlfO1PprM6/j4iOvWVx1nkD0AJxLkDhWf19m+wqMtvcS8gax3vVHTFKAN5nEvmedxFWFgR2Utqkb9hSWdJepekCyV9y8xObt3IOXeNc26mc27mjBkzEto1AGBQLPLXHTGUDWahAPGUrayULLiIEDffscgf0BmDbfVR6aqq0geHXsUZYN4i6YzA36f77wVtljTbOXfUObdB0hp5A86oANo+1FXeeb/5eaTphqbOM7Sz7uBzQtGsNTqKNtsidLsUwpjmYZclyzlm3FUaSdpZ1eKnzM9g5tEc3WUZLa7tRX2F9ddrl0dd97OWLM+hmvYb8Velk6jSB4dexRlgXijpLDM708ymSbpA0uyWbf5N3uxlmdmp8h6ZsT65YCIPXIwCAOQmj0aITjIKrsyPGyhz2JEPZigDaCjb3ZZ1afJqcpiIqesAs3NuTNKlku6StFLSTc655WZ2uZmd6292l6RdZrZC0v2SPuWc25VWoJG8Os9ebFeuxgv1ULZOVR6IIQysIJko6UGVxs8xWAOgTJhJDCnQNJekDcv+zrj6FY6SZAWgdobjbOScmytpbst7lwVeO0mf9P8BJVe/Rhrd1bDvVnitaVK1JOLCX32xyB+AMohTpVDt5IPBecDjXDH61HmUwzzrgTJd+ChRUAsvqUX+AAAlxgzpaGXqICEmP01JWSA7xhT6Wskitauepeh/VBupm6/J4kVCDKS3apjIrjoGmEuIzgaQjbzLWtOCVyzyl5q4x87gSDrybtJc5B/ZSrO+KU3pLkpilETZaqS829SiK0v8xM13pV7kr2nB0XKkS1D5QtwZi/wdE5Yd6xgtXRf5yylWgvVFXdKlCsfJKV5yGGBGVyXsVwEAEM3vSdKfBABUXRqDJ5wfIi9JZb3JcpFSZ7CMF6eAQTHADAAx5N1F4BEW7fJOk9RV/gC7qPvxJ4jaA0VAka6eOOMnyY2xkIN6EYytso9zlW2RP6Svl6zgXPnLQL9ch78S20dE5JYpyuuaP9LAADMicasAAKDq+ulU0j4CQLYYAIiPJgpVRN8LKD4GmCGJThtQd8yQRlFwAgFEK3N3jaJdL0mnd1jbUPX2oszlvc6yfv4v5/HFV+Wqqpc1asir1ccAcwlRLoF6yLIRrvUifxkfOp2rVjkvplmQBClGKPJVpVu60Y4k7axq8VPqRf4Cv1vGdCljmOsoqfxLerfLqw/hIl5XWVH60SgGBpiBNlW+xghUV9oll5oBWUlrVl7VZ/vVTS+zhoCkkO0AoDvGXcuDdi05DDCjq/rNbKzb8SIOrs4WT2uaVC2FqnY8cWU7c7/P76Ucxixm5QHAoOKcIwxyHhH8LvVXb5pnYScfefU7P0RR9FoXONclt2aQlZ3yOZfM8/y1THV2mcJadAwwAwAAqL6D+gBQdAwAAOgHVYeHOhRZYIAZkiIWzuCGcKA2KO8onBSzZPCnecwAACQviZo12Dep4yJ//WqNFvp42co6vuuSumU7Tuon1BEDzCXE1ScgG3mXtSx3X+dbHbulc9L5oM5xHSb3cpZ3AHwFCUauyr6wFjojj3dWtfgp9SJ/Gewjjn73XbGsVFn99AfD8gTp3S6vOGnqx9QkYXo5zJpESa0xwAxJ9akA4+FyI1BGlFxUBYv8IQr9NQAotqwnEhTlQnnZpH0HG6mCOmKAGWhDc4B25IriaU2TtNMo68G52p8v1Pj4WeQPcXC9APkI5Lw4dUpC9Q71V2+aFkisc4OK2nMufBA+64H5PEphniWfeqeeGGAGAAC1RfcXAIqJAQoASAa1KbLAADO6YsYAACAreT7GIe5sFh41AQCdZVFNUhfnh/ND5KXXC09FuFBFVYW6YIC5hLKqJOm0oe7y7pBkeetWnU8Usn9WXqa7K7y8o6MwC8vlHREF0HRLN/GBuqlYnk/icKzLsEwWjxOqWLKg5PI+N8lTL2MT+fUhgv2YeqRVTQ4TMTHADLRhZB0oo7RKbp0788gHi/wBAOh9VBwJnKu0F/lDOwajq48BZqANNR/a0SAWT2uaVC2JGNiuLxb5A1AGGa7xR5vYI+p7wONceD2U+SJ/NVvljzqonhhghqTqDcwAQNK63aoLAFli8hXykGW+Y1AZZZT1wBoDeYijLo/sQL4YYC4h6gYgG3mXNdf0Ot3A1LlayfxEINvdFV6hylmeMz1SzBllyXNNzz3NO2MUFANu1UXaFocr+XNUyxjmTlzbi/oKS9o61h3djjivOGnux+QSBCBXsQaYzewcM1ttZmvNbFaH7T5oZs7MZiYXROSNuhEAkJUyDPJy0gAAAJC9XvtgeXXZmi5U5RSGLFT52NC7rgPMZjYk6SpJ75V0tqQLzezskO1OlPTnkhYkHUjko753Xtb3yFFcPJ6hO2KoYjJK0CLmm6RvQW/8HI9UAFAm9H36U7XFy6ztRTUwMNebYL5OIitUrZwARRBnBvPbJK11zq13zo1KulHSeSHbfU7SFyUdTjB8QA5o7hGCbFE4rbNN00qivGar1n6WbI2Pn0X+AJRBnDolqXqnjvXXII+6KMrjn4C8OafQPmXmi/zl0LEt2uNTihaeBurI5MQZYD5N0qbA35v99yaZ2VskneGcm9Pph8zsEjNbZGaLduzY0XNgAQAAkkSfEgCKqaiDEQAAoN3Ai/yZ2RRJX5H0F922dc5d45yb6ZybOWPGjEF3XVt0tYBs5H01M8v9V21BmDQkdScdcd0szwEE55rTI9fnP5MtWhY2RTfc3VstZakD6pDtypIWUehnVFdYypLc7eLESeMRGUlGX9SdA0WoN8km0ehPJSfOAPMWSWcE/j7df6/hREk/J+kBM3tW0tslzWahv3KhIxJEDQOUESUXcQ3akUy7I5rW79OBBgAgXVmfVXMW3x+6REDy4gwwL5R0lpmdaWbTJF0gaXbjQ+fcPufcqc65EefciKTHJJ3rnFuUSoiROQafAQB1QGsHAEB3nB4iL71nPTJrmhgrQlDXAWbn3JikSyXdJWmlpJucc8vN7HIzOzftACI/9V1ZlUoS7XgOYPG09meqlkJVOx7ExyJ/iEIaokji9I0G6T9ZYI4hWT8+M2t+/FOOYUE0Buay4Vx4PZT5TPMckptHv8VTprAW3XCcjZxzcyXNbXnvsoht3zV4sAAAKAY6HWhFngCA9HFxHwCSUYS+axHCgHQNvMgfskfBBLKR+4lNlov8Zberwsm6Tq1zXIcpVJuW50yP/HZdGEVZcBHIA1m+mMpYFzEztrrC0pbkLo5gWpAuqCMGmIE2dX00CFBuaZdcagY0sMgfisColZCD+j5CD0CVpF2T5T5RCbHRrCWHAWYAAAAAAAAAQF8YYAbacLUR7bjNqfjSTqLsFwOpaaYrwWGnnTQs8oc4mB2FPPT6KBvqnfylkQbUP4MjBrPhFF4GMu/XZ7y/vPZ5bN/lyeG0U8lhgBkAgA64bQoAgN5k0XTSPgNAvnp5bFJR6+wyDYYXHQPMpUQBALKQ99XMLBu7vI81T93iOem4qXNch8k7PpoWZMmxfa3tjPUA1/Sa+EC9VK0OSOJoui2Yld7dHoFZ2tRFKJCw3EgebZdXfRpMi4pV6ZF6ieu6xEmdMcAMAKgEFvlDVljkD0XAIn/IA4v8AaiC9Bf5Q1nQn0oOA8wAAAAAAABABVXtLhkUEwPMQAvqXoQhWxRPa1mtWhpRFxUXi/wBQLx2l2onH0V5/BOi0SZnwzlXjEX+ckjv5nogv30XHXVkchhgLqGsC2uZKgcgSXln/WxPDvI+2vxkXsfVN6pD5d2pK8rz8tLcdWmynIt4DdQAWb44uj37ueiyCHOW8eLaXtRXls8iLyrnumeFvOLE0Y9BzTHADAAAIM4FAKCo8r4YCcRVtwHfossrOepSZ9XjKBEXA8wAUAIsPtBdWjFUlw5iPRUzbZNeQ6vxc6zNBQDl0e9AZdXqemt7gToK5uskskLjN3g2cXaI6upjgBkAgDg4sYGvaifvKCnyIXJAtgMAVAkTuZLDADPQggtrCMPV7eJpnVlMClVLmukZ7EgWsWizyB+ikIYokjh9I/pP+WjqI5EEqLE4z2xOQ/ugZfahyPMuzDJVO9ytmhwGmEuIfhqQkZzLWvM6EekGps71SvZr/NU4skPknfeaylmOgUlz12XJcU0LLuYYDiAPedeFOKbs63RVLS9VdZG//g6n/Vt1vIjTdZG/TEIRst+IBdqNW99QEwwwAwCAwijDAHwNz+UAIHMu8g/kjeRAXsrQT5RaBpvpOKImGGAGgBLg2VDdEUMYVFG6/yzyBwCAh0X+0KqXrBA1uEufKCFF6TyjEBhghqTw2VhUugDAbNW8ZNUE0dQBQDHVvX7ud6Ym53D5KssM27Jhsk35UTaqjwFmoAWDSQhDtiie1rKadhpl3bGlLiqutJOGRf4QB6fayENw8DJOlUK9k4/mZ8GiyihjnTmFz2LOOt7ySKemfWZ+vGTMOmKAuYS48gNkI++ylmXDXOdaJesOEP2t/DXKduvK4nmmTd71TRE0P68wv3AAeaAOKI6y10VlDHMd9dP/DPsKyd2ul6hNsrwUebHiooUH1RRrgNnMzjGz1Wa21sxmhXz+STNbYWbLzOw+M3t98kEFACAas/lQFWnd3sxt0wAAAOljBi/qqOsAs5kNSbpK0nslnS3pQjM7u2WzJyTNdM79vKRbJH0p6YAiP9SNAIAqaTzuhAFXlA2zXFEnOd7djS4YPENuEsp6jT4gfUEgOXFmML9N0lrn3Hrn3KikGyWdF9zAOXe/c+6g/+djkk5PNpgAAAAAAABATFwLSRUXvhEUZ4D5NEmbAn9v9t+LcrGkOwYJFIqhrlfzqCQRhokaxdOaJGklUV5JX/e6KKujL2LZZpE/AKWQcp1S01ORSf3W2Watz5Gm8kf59Ts24RReVdVikb/sd9lx31RF1Tec5I+Z2e9Jminpv0R8fomkSyTpda97XZK7rpU0CmbdBzKAMHk3glnuPu9jzVPcQ0/qoluNozpU3nmvMO1fQYKRp6YBESKkK6vrTICqKkmWtxoM+zYv1FWShAnIu12tvRTjn0G7ePIqt839GKB+4sxg3iLpjMDfp/vvNTGzX5f0GUnnOueOhP2Qc+4a59xM59zMGTNm9BNeAABCVf+UF3XBIn8AAFRbUgOQZbwIUgRp94kY+EcdxRlgXijpLDM708ymSbpA0uzgBmb2ZknflDe4vD35YAIAAAAA6qJpkT9GawAAKLSuA8zOuTFJl0q6S9JKSTc555ab2eVmdq6/2ZclnSDpZjN70sxmR/wcAAAAAAAAAKAiYj2D2Tk3V9LclvcuC7z+9YTDhQ6yvn5ft9tumCCBhqaZMzmUgyyfR1rGct46m6nfI8h+kY94O6xLXdSa97I87r73lcpaCIHXCf9+4+eKnqfSjAOg6MqY5eP0HcpYlpsXyMsvHINwEa/T+P20ubYX9VXW/JikqEX7mrZpWeSyU7yltrByy+tczrUCB5fWXSBRP1umvFqmsBZdnEdkoAbCFuyowyIeANAVnY5cpNkCDfrcvTJekEE1cBKEOqn7mQjFvaTqnnFT0m+0Uo48xAOywAAzAJQAF3y6SzuGSAGUVSPvsshftZCcyAP1CLJmbS8qghG/viWRFaqWndA/2rXkMMAMScWbjcVCHgAAAEB9pf2YByAVZFYANcUAM9CCsW2EIl8UTmuSVC2JqnY8varz8ad10Zf2DUCS4tQpSdVn1F+9cU3PXs0xIEgd6duZFz/tkZT5ulZ5PII5+10WZOe9oQwlhwHmEqIAANnIeyZ98KQs9UX+al2vZHvwtY7qEHnnvbz335BmOApyiF01DYjkGA4gD0Wpi1D++qdod6YOikX+jgk7N6ljtHRd5C+TUITsl9WKUXMMMKMr6kYAdVa1EzUAAMqmjs/ILPI5WJHDhmrrdQJQXv34uhSRXpKDeqP6GGBGpDp25ICiYpG/7oghIByL/AEoI6qs/lStz1jZRf7Qk2AfhkX+gGJigBkAgBiM0TkABUKVhKrjbnNUGXfIAcVAfyo5DDADLWjsEYZcUTytJ5tVS6O8nwGO/KSV9GSp8iMJUSSxFvlLKNOS93vjIl4DdeNceD2U+SJ/Ge9PyrffV6YxFfrHyWGAuYTSKKxFK1RFCw/qKfds6IIvWeQvLVkfe53jOkze0dHPQH4aaZhmGc87juNqnq1YllADySjTyXjlBRccLWFdVLW8VLZF/tIMZuhvlzCPDqrrEecUJ00LtBcsWYoWHlQTA8wAAAAAgMLiDmYgHOOGxVS1Cz1AHAwwoyuqRiB/VVuwJQ1pxRBX/LNVhuguQxiDWOQPAMqn0ANUGQaNRf4QlFS/PMvsxLmEp9B1GhLBADMAAAAAAEBGGHTMBtHsSWtwl0FjBDHAjEh1vUhMY48w5IsCyniRv6xnf5LlsmEFnNabVtpTj1ULd7YgD8EqM06VklS1Q/UVn8ma1/Gg8kcF9N3mufD6I/NF/nIohnmWfaqdemKAuYworJVE56948k6SLHdf56vP2a8iXd+4DpN33Zf3/hsKEoxcBeOA6EDdUAd0FlZXp3Yxrmm/Ke0kRfQzqissP5Yxjw6qW98tryhp6sfUMF0ABpgBAJXAXD70yrl6nQAUcLI2elSUCyJA1op4twmA8mrUKNw1BiSHAWZIKl4FWLDgAAAAAADQERcCAdQVA8zoikYSQJ1RA1YP8+AAAEVX5FMwHsNRHHVLi6SONu27Irjpol2R6zQkgwHmEqJcVhMVbvE0PYMvh5LX/DzSdPdfxvzXGif9HkLmxx5zf2VMk37kfZh577+h+ZmfyYaq8WvFz1M8hBn1VcYs37GucjG2GXBfaU2CqcLz4IN9pLIeQ4Nre1EN/WTfsPOB4rftyet2yK3nUOHPrk4+4jo9vz2Xc8ks9hGxkxpmS4gBZnTAs84A4BhqRDRwZw+KgG4a8mA5tYbUukC99dvm5dVlK1qdlVY8FO04kS8GmAGgBPI6oSsTYggI1ygbDEgCyEzC9Q3VV31Z2wtgcEymSwaxiKBYA8xmdo6ZrTaztWY2K+Tz6Wb2Q//zBWY2knhIAQAAAAAAAACF0nWA2cyGJF0l6b2SzpZ0oZmd3bLZxZL2OOd+WtJXJX0x6YACAAAAAAAAAIplOMY2b5O01jm3XpLM7EZJ50laEdjmPEmf9V/fIulKMzPHQwrbbN9/WA+v3TnQbzy36yXdtmTz5N/B10FR74d5cM2OtltnN+x8SZJ05/IX9P+84rjeAzqA25Zs1tCUeDdc9HKccdy3crvWbDsQe/uk9n/bE1sU85ALJywOkk6XPOx5aXTy9dynXtApL5ua6f73Hjw6+XrBhl06bmp6TzXavOdQ099x0y/PdH5pdLzp71UvHOgYnqjPHlyzXZv3HIz83rLNeyVJ96zcpo27o7eLa85TW3XS8d3z0j0rtk3uu8qe3XUsTm9bslkvHRmTJL14ZKzn/BW3Lpr3zA5J0sJnd+vZXdO7bt9qyca9ief93YH65v7VOybb4CQs3rhHkne8SYY76ThYtnnf5OtH1u7UnoOjHbaup8NHJyZf37tym7btP5xjaHpXhb5BWoJ1QJbx1Mu+bluyuakdnL9+l1706+xWBw5779+9YptefeLevsI2OnYsvy9/fn/b5xMunbha9cKxfa14fn9u+fbRdTv1mpN6Pwebv26XZpx4rG3bvOdQz+ncTbAPFmf7QeJwid+GxU2LvOuZx9bHa2sXPbdn8nXcMD+z/cW29x5Zt6vn3ymjxhjKgg272s6Zt+xtPo8JluGxCacFG3ap1aqt+yd/r1u8xY3X5wJ92uB4wtyntmrjrvZziLTTa+mmvZOvj4xNpLK/pZvD+8QvhbQN96zYpnU72vNw3lZv63wOGeYXzjhZb5hxQkohKi/rNgZsZudLOsc59zH/7w9L+kXn3KWBbZ72t9ns/73O32Zny29dIukSSXrd61731ueeey7JYymFh5/Zqd/79oK8gwEgplccN6z9h8NPngAAAFA9p54wXeMTE9oTuNgPFMVZrz4hdLAZQDY+d97/qw//0kjewciFmS12zs0M+yzODObEOOeukXSNJM2cObOWs5vf+vpT9OCn3hV7+wknveqEaRobdxqbmNAJ04e148ARSd5VqGlDU9pmHh8dd5pi6joD+MjYhEzeyp/Th8NnRh4Zm4j8LCkHR8d13NQhjY5NaGxiQlPM9LJpQ12/55w04Vzsmc6dfsdMOuOUl+m53QdjzyJ2ThodTyZ+TCZXwjVYxyecJpzT1CEvDpyT9h46qhOmD2vqUEmnY7d47cnHa8eBIzo6PtF94xRMHZqS2b4nnHTS8VN14HD3k6m49Uzahoem6NUnTtfmPYdCy67JNDYxERrOoSkmM9NYjPhNqi6ccIqsY0bHJjTsl6XRsYlUZ6wXzdShKRodm5hsz3qJ7wknjU9MTNZDkjdbZfrwFE1MKLJuDe5j6tAUHRwd71pvHR13Onx0XCcel173aWzCaTiFcjU+MXh7KXnxPXXIND6RTpt1/FSv/T90dLzLlvW179BRTTFLNR8mraz9nKylVf6DGu33FLPYC386Jx0dn9C04WNt1Mkvm6aDo50vwCdxPMdPG9LRcaex8QkdPjqhqUOmKWZ6+fRhHRodTy1fnfLyaZKa72bLyo4DR/SK46f23O9oPTc6fuqQpg8Pae+heMcw4aSxQDp306mtPjI2oVe+fJq27z+iacNTBj4vaJyvRZlw0pGxcQ1PGXxfvZhw3t0Hrz35OO16cVTDQzbZjsUxPDQlVj806PhpQzr5+GnasvfQZP/n0NFxDZnFTruyCua58Qmng6PjOmH6sMy8emn68JBOfvlU7XlpVBN+vdXYvhHXLx0Z1/CQafrwlK79zcZczF7WA5w6NEVOXlmaPjykI2PH+jOvPvE4HTh8VPsOHdXw0JRM7l4+YfqwDhweS2Wh50NHxzvm90YbcMS/GyXtcaVejU944xgTfTx4odFGoFmcnukWSWcE/j7dfy9sm81mNizpJEnt9yFAx08b0utf9fKBfuP1ryrPCUXZnHnqYGmDanrtycfnHYRMvbKEDSZlFwCArE3vvknJveK4bB+PJmngc8VWJ2X8iLegU0+ofh5p9EFfc1K25wv0faPlUW7jOn7akF6d8eNHX1WDcohiiHMJYaGks8zsTDObJukCSbNbtpkt6SP+6/Ml/YTnLwMAAAAAAABAtXWdCuucGzOzSyXdJWlI0necc8vN7HJJi5xzsyV9W9L3zWytpN3yBqEBAAAAAAAAABUW61kLzrm5kua2vHdZ4PVhSb+VbNAAAAAAAAAAAEVWrKdsAwAAAAAAAABKgwFmAAAAAAAAAEBfLK+1+Mxsh6Tnctl5/k6VtDPvQADoC+UXKCfKLlBOlF2gnCi7QHlRfhHl9c65GWEf5DbAXGdmtsg5NzPvcADoHeUXKCfKLlBOlF2gnCi7QHlRftEPHpEBAAAAAAAAAOgLA8wAAAAAAAAAgL4wwJyPa/IOAIC+UX6BcqLsAuVE2QXKibILlBflFz3jGcwAAAAAAAAAgL4wgxkAAAAAAAAA0JdSDDCb2Rlmdr+ZrTCz5Wb254HPXmlm95jZM/7/p/jvf8jMlpnZU2b2qJn9QuA73zGz7Wb2dJf9nmNmq81srZnNCrz/q2a2xMyeNrN/MbPhiO9/28yW+uG4xcxO8N+fbmY/9H93gZmNhHz3TWY23z/eZWb2O4HPrvfD9bR/LFMj9n+nme01s9tb3o/7/Y/48fqMmX0k8P5b/Xhda2b/ZGbWKR5RXzmW3dDtovYZ8v1L/fztzOzUkM//k5mNmdn5PR7z5/xje9LM7jaz14Z8//V+/fKk//2PBz77P2a2ycxe7HL8f+2Hf7WZvSfwfmidBrQqcdkNbd/M7CQz+7F5bfJyM7uox2P+Lf+9CTMLXVG7y/e/bGar/Pj5kZmdHPEbUf2OM83rL6w1r/8wrVM8or4KWHa7lp1O25nZq/zjedHMruzw/dB2O07Zb/md2cFjMLPPmtkWv01+0szeF/E9yi4GVuLyG9rGmdmImR0KlJ+rI74/UPk175y3sc3VZjbUKc5Cvs85LwZSwLIbt98ZFbZT/O8tM7PHzeznIr4fem5qZh81sx2Bsv+xiO8/4Ledje1e7b/fdbzM3462t2icc4X/J+k1kt7ivz5R0hpJZ/t/f0nSLP/1LElf9F+/Q9Ip/uv3SloQ+L1fkfQWSU932OeQpHWSfkrSNElLJZ0tb1B+k6Q3+ttdLuniiN94ReD1VwLh/BNJV/uvL5D0w5DvvlHSWf7r10raKulk/+/3STL/3w8k/XHE/n9N0m9Kur3l/a7fl/RKSev9/0/xXzfi83FJb/e/f4ek9+adR/hXzH95lN1O20XtM+T7b5Y0IulZSae2fDYk6SeS5ko6v8djDtYJf9aoB1q+P03SdP/1CX4YXuv//Xb/91/scOxn+/XVdElnyqvHhhRRp+WdR/hXzH8lLruh7ZukvwmEc4ak3ZKm9XDM/1HSz0h6QNLMPuLs3ZKG/ddfDAt/pzIq6SZJF/ivr1ZEu88//hWw7HYtO522k/RySf9Z0sclXdnh+6HtdpyyH9j2v0u6IXgMkj4r6S+7HDtll3+J/Ctx+Q1t4/wy2XHf/nYDlV/5/Wt5bf+tgTLXte8gznn5l8C/Apbdrv3OLmH7sqS/9V//rKT7Ir4fem4q6aPq0GYHtgutWxRvvIy2t4D/SjGD2Tm31Tm3xH99QNJKSaf5H58n6V/81/8i6f3+do865/b47z8m6fTA782T10B18jZJa51z651zo5Ju9Pf1Kkmjzrk1/nb3SPpgRLj3S5J/tfN4SS4kzLdI+rXWK6LOuTXOuWf8189L2i6vYZVzbq7zyWv4TlcI59x9kg6EvB/n+++RdI9zbrcfj/dIOsfMXiOvEX/M//735Mc50Cqnsttpu9B9hnz/CefcsxE//wl5ndftEd+NPOZGneB7uY7VCcHvjzrnjvh/TlfgThO/3G2NCFfDeZJudM4dcc5tkLRWXn0WVacBbUpcdqPaNyfpRL+tPcHfx1jcY3bOrXTOre4S9k7fv9s519hfU9wEhJZRP8y/Kq+/0PH4gaKV3Thlp9N2zrmXnHMPSzrc5ftR7XbXsi9J5t1l+ElJn+8W1hCUXSSixOU3ThvX6fsDld9A/3pY3kBT2Dl3VPnjnBcDK2DZjVsmo8rI2fImVMk5t0rSiJn9h5D9xDk37UfX8TLR9hZSKQaYg/zp8W+WtMB/6z8EMvULktoyvqSL5V117MVp8mYqN2z239spadiO3SZ0vqQzOoT3u364flbSP7f+tl/w98kbuI76jbfJayzXtbw/VdKHJd3p/z3TzK6Nd3hdvx91/Kf5r1vfBzrKsOx2EmefkczsNEkfkPSNmNuPqPmYJ28lkvQhSZf57zWVXf82q2XyyuAX/YtMnfZzrpld7v/ZqeyGvQ90VMay29q+SbpS3kys5yU9JenPnXMTHb4/opayG7Hda81sbo/f/wP5cdPy/agy+ipJewMnCpRdxFKQspu3yLJvZk8GtvucpH+UdDDkNy71bxP+TuD2YcouUlXi8jvZxvnONLMnzOxBM3tnj78Vt/zKzO6SN/njgI4NLIXGGee8SFMBy25rmQyKCttSeXf1NMaiXq8eLxxJ+qAde1Ts5HhZa9mV9F3/8Rj/OzCIHDpeRttbfKUaYPZnF9wq6X+0zASUJPlXF13Ld/6rvAL76STC4O/jAklfNbPH5TVi4x22v0jeIy5WSvqdqO2i+FdPvy/popCT4a9Lmuece8jf1yLnXOjzbSIM+n0gliKU3Tj7jOEKSZ/uNDDVEHXMzrnPOOfOkHS9pEv995rKnnNuk3Pu5yX9tKSPhF0xbjmW2c65y3o8FqCrEpfdpvZN3gylJ+W1x2+SdKWZvSLsi92OuSUszzvnmp7J2un7ZvYZebOvro/6PpCEIpbdnESWfefcmyTJzN4k6Q3OuR+FfP8bkt7gf3ervEFoyi5SVdby29rGySszr3POvVneHQI3RLW9EbqW3wbn3Hvk3ao/Xd7sRbV8PhlnnPMiLUUruyFlMlJL2P5B0sn+YPAnJD2hDmNeIX4sacQ/n71Hx2Yjt5bdDznn/j9J7/T/fbhLGGl7C640A8z+bKRbJV3vnLst8NE2fxC2MRi7PfCdn5d0raTznHO7uvz+GXbs4eIfl7RFzTOTT/ffk3NuvnPunc65t0maJ+8ZOzKzu/zvN80ids6Ny5uy33iUxuRvm7dA4EmS2sLnN6BzJH3GOfdYy2d/K++RGZ/sdFwdjrfb96OOf4uar15NxgsQJoey20noPqPKboiZkm40s2fl3b3wdTN7f0iYoo456HpFPF6nwZ+5/LS8BjeuTmU3tE4DwpS17Ea0bxdJus151kraIO/OorjHHEun75vZRyX9N3md6bAB8qgyukteJ3+45X0gVMHKbtRvNGYstd0BkLA4Zf+XJM302/aHJb3RzB6QJOfcNufcuH9h+VvybsltRdlFYspafsPaOOc9rm2X/3qxvLtx39jDrmK13Q3OucOS/l3HHgEXGWcBnPMiEUUru2FlMqTshobNObffOXeRPxj8+/L61eu7RoLPObfLHXvk47WS3hqxXWN87YC8NRAabWyc8TLa3gIqxQCzP1X+25JWOue+0vLxbEkf8V9/RF6jIjN7naTbJH3YHXteciR/xuCb/H9XS1oo6SzzVqCcJm/W8mz/tydXt5R3pelq/zfe43//Y+b56UD4z5W0KiTM50v6SevJpr/PH0n6nnPulpbPPibviu6FcWZStor5/bskvdu8FURPkfeg+LucdwvFfjN7u39cvy8/zoFWOZXdTkL3GSy7XfZ1pnNuxDk3Iu/2uz9xzv1bcJtOx2xmZwX+PE/H6oTgNqeb2fH+61PkLW7U9fl3AbMlXWDe6rtnSjpL3rNoI+s0oFVZy26H9m2jvIVvZd4dAT+jlo5yl2PuqkvZP0fSX0k61zkXdgu+FFFG/f7B/fL6C03HD7QqYNmN+o2L/O+nPROpa9l3zn3DOfdav23/z5LWOOfe5X/nNYFNPyDvom8ryi4SUdbyG9XGmdkMMxvyX/+UvD5p7EEqxWu7TwgMkA1L+v8Vfs4dVf4458XAilZ2o8pkSNsbFbaT/fZMkj4m767Ajnf1tew/2HaeK+9u/tZths3sVP/1VHmD4Y02tut4mWh7i8kVYKXBbv/kdfacpGXybpN5UtL7/M9eJek+Sc9IulfSK/33r5W0J7D9osDv/UDeLTtH5T2T5eKI/b5P3uzkdfJmETfe/7K8QrJa3u0PYd+dIukRec+LelrebMXGCrfHSbpZ3uJbj0v6qZDv/54fvicD/97kfzbmh6nx/mX++zMlXRv4jYck7ZB0yD/O9/T4/T/ww7hW3iM6FNjuaf83rpRkeecR/hXzX45lN3S7qH2GfP/P/O+NyXvu27Uh21wn6fwej/lWv+wsk3fr0Gn++5NlT9Jv+J8v9f+/JPDbX/LDNeH//1n//XMlXR7Y7jN++VytwIrXiqjT+Me/1n8lLrtR7dtrJd2tY23y7/V4zB/ww3NE0jZ5J5+N350b4/tr5T0nrvH+1a3f9/+O6nf8lLz+wlp5/YfpeecR/hXzXwHLbmjZCfl+5HaSnpW3iNGL/jZnh3w/tN3uVPYlPRnyOyOSng78/X3/u8vknfC+JvC7lF3+JfqvxOU3qo37oKTl/ntLJP1mxPf7Lr/ynhm70I+zp+WteTTcJc445+Vfov8KWHZDy2TI96PC9kvy2rTV8gbBT4n4ftS56Rf8sr9U3mDvzwa+86T//8slLfbjbLmkr0ka8j8LHS8TbW/h/5mfAAAAAAAAAAAA9KQUj8gAAAAAAAAAABQPA8wAAAAAAAAAgL4wwAwAAAAAAAAA6AsDzAAAAAAAAACAvjDADAAAAAAAAADoCwPMAAAAgCQz+6yZ/WWHz99vZmfH+J2m7czscjP79aTCCQAAABQJA8wAAABAPO+X1HWAuXU759xlzrl7UwoTAAAAkCsGmAEAAFBbZvYZM1tjZg9L+hn/vT80s4VmttTMbjWzl5nZOySdK+nLZvakmb3B/3enmS02s4fM7GcjtrvOzM73f/tZM/uC/9kiM3uLmd1lZuvM7OOBcH3KD8MyM/u7HKIGAAAAiGU47wAAAAAAeTCzt0q6QNKb5PWLl0haLOk259y3/G0+L+li59w/m9lsSbc7527xP7tP0sedc8+Y2S9K+rpz7ldDtmvd9Ubn3JvM7KuSrpP0y5KOk/S0pKvN7N2SzpL0NkkmabaZ/Ypzbl5acQEAAAD0iwFmAAAA1NU7Jf3IOXdQkvyBYUn6OX9g+WRJJ0i6q/WLZnaCpHdIujkwgDw95n4b+3lK0gnOuQOSDpjZETM7WdK7/X9P+NudIG/AmQFmAAAAFA4DzAAAAECz6yS93zm31Mw+KuldIdtMkbTXOfemPn7/iP//ROB14+9hebOWv+Cc+2Yfvw0AAABkimcwAwAAoK7mSXq/mR1vZidK+k3//RMlbTWzqZI+FNj+gP+ZnHP7JW0ws9+SJPP8Qut2fbpL0h/4s6RlZqeZ2asH+D0AAAAgNQwwAwAAoJacc0sk/VDSUkl3SFrof/S/JS2Q9IikVYGv3CjpU2b2hJm9Qd7g88VmtlTScknnRWzXa7julnSDpPlm9pSkWzTYgDUAAACQGnPO5R0GAAAAAAAAAEAJMYMZAAAAAAAAANAXBpgBAAAAAAAAAH1hgBkAAAAAAAAA0BcGmAEAAAAAAAAAfWGAGQAAAAAAAADQFwaYAQAAAAAAAAB9YYAZAAAAAAAAANAXBpgBAAAAAAAAAH35vwewEb9KGZR9AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1800x216 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data1[\"target\"].plot(figsize=(25, 3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b92243cd-a79d-4886-a11f-38e43a5dd9b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='datetime'>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABZgAAADQCAYAAACKngRiAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAABPpklEQVR4nO3dedwdZX3///cn952EyCIo0SqLNypq+bUqGvfaWmsr2gq2Wot1X8rXVuxiq8ZqLcW61aqtilJEpVoUWUSjAQFBBGQNkgQCJGQBkhDIHrIn931fvz/OnDtnmTln5pxZrpl5PR+PG07OmeW6rrm2uWa5zDknAAAAAAAAAACSmlZ0AAAAAAAAAAAA5cQAMwAAAAAAAABgIAwwAwAAAAAAAAAGwgAzAAAAAAAAAGAgDDADAAAAAAAAAAbCADMAAAAAAAAAYCCjRe34yCOPdGNjY0XtHgAAAAAAAAAQw+23377ROTc77LfCBpjHxsa0YMGConYPAAAAAAAAAIjBzB6I+o1XZAAAAAAAAAAABsIAMwAAAAAAAABgIH0HmM3sW2a23szuivjdzOzLZrbczBab2fPSDyYAAAAAAAAAwDdx7mA+T9JJPX5/jaTjg7/TJH19+GABAAAAAAAAAHzXd4DZOXedpM09FjlF0ndcw82SDjezJ6UVwLpb8tA2feTixfrHCxfpQxct0tjc+Xrxp6+WJF16xxrd/dCjXet85er7NDZ3vt77v70nUXzD12/U2Nz5esbHLte2Xfu7fl+/fY9+53PXaO3W3elEJsTD2/bony+9U18Owjw2d75O/uoNcs71XffKJQ/rrF8sH2r/l9y+RhcuWK3nffIq/fGXr9fY3Pl6eNueWOteu3S9nv7Pl+mc61ZIkpxzGps7XyeeeWWiMHz92hUamztfD2WYzv1E5aV+PnTRIn3t2gPHYPXmXfroD+/UpXesSTN4euu5t2hs7nzt3Ds+0Pr3PbJdX7pqWax81erGFRv1oYsW6QtXLtWXrlqmJQ9ti1x29eZd+v3/vFbvOe+2gcIY5RvXrdTHf3SnNu7Ym+p2Oznn9CdfaZSBW1f1qvIb3v+9X2ts7nzdtTY6TbJ2+wNbdOo5N+n95zfC8sCmnW2/b9u1X6/7yg368MWLtHz99rbfblyxUc/8+OUamztfn/zp3fr2r1ZJks771aquOm/9o3tSieviNVun6osw8xev0x0PbtHC1Vv14YsX6Yb7Ng61v7Jwzuk/r1iq7950/9R351y3Qv900SKtf7R/fXzrqs16xscu17/86MCDVudct0LP+PjlkXXR7n0TevYZV+iiBas1PjGpT192jz588SLd8eCWnvs66xfLNTZ3vn5w24PxIpfQxy69U2Nz5+veh5PXx708uGmXzpi3ROu3x2vferlpxSZ96KJFunDB6ljLv/1bt+qS2+O1CXvHJ/TJn96tM+Yt0e59E8MEs9LefM7N+stv3Bzad/PRj+5Yq4/+cLHu39heR6/f3qhbP/rDO3MP0/L12zXn33+u/ROTue87yt7xCX1q/t2plv971j2qP/rSL7V5576p7z57+b36p4sW6dzrV+ozl9+jycnefaMlD23TCz71c73p7Jum+lFn/WK5/u0nS7Rnf3Q5/b+bH9DLPnuNFq3eKkl6YNNOfffmyHmBQm3Yvlcf/9Gd+tT8u/XwtkZ+uXbpel119yMamzs/0fZ+dtfDWnB///6NJK3btlv/fOmd+udL78z0PCjM/Rt3amzufP3hF38Zue9HHt2jc69f2fX9HQ9u0djc+Xr9Wb/S9j37dca8JfrwxYv0ge/f0ZYHoty1dpt+vHBtz2XufujRqfOv8361SnP+/edauWFH13IXLlitE8+8UmNz54eGNY6VG3boG9et1Cv/89qpNInqy7/0M1frqR+dr4titk1J3bRik66+55Gu729cvlFjc+frtO8s0D/8YKHG5s7XLSs3xdrmo3v2a2zufP32v16h8Zh10eSk02cuv0cfumiRXvPf1+u5Z16ph7bu1s/uWqfv3dLeN/np4od05ZKHY203iWvufUQ3rWiP4+vP+pVe+YVrU9/XtUvX61fLN+pnd63TzSs36ctX36c9+ye0eee+qbGD5nl08/N7zrtN37hupRav2aqxufP144VrtXrzrrblx+bO1+nf+7X+++f3RdZjcy9ZrLG583XPuu46+aGtu6fOHSTpF0vX6wWf+rluWblJz/m3K/WiT/9cNy7fqP/6+TK96NM/168f3KJlj2zXRy5erH/50V366/+7XWNz52tHx7ntdcs26Pr7NqSWflt27tMnfnyX5l6yWPc9sr3/CgksX79Dz/z45Vq9eVfkMt+6YZXOv+UBvfd/b9MzPna5zv7lisi+6LZd+/X5K+5tOx63rtqssbnz9eWr70s17E2L12zV7//ntfqPn92byfbraDSFbRwlqbUmXxN8t65zQTM7TY27nHXsscemsOvq+/HCh/SDjoby4eCE+x9+sEiSdP9n/7jt9y9ctUyS9POQRrDV7Q80TqT3TUzqRwvX6h0vHWv7/dRzbtaaLbv1ss9e07WPtFy3bENXY7h4zTZt3LFPsw+d2XPd0757uyTpPb9znA6aPjLQ/v/xokVTn5sdr3efd5su+7uX9133nd9uDCR++rJ7ddrvPk33rW90rrbs2q89+ydih+lzQYX2N+f/Wj96/8sShT8tUXmpn4uCQYO/ecXTJUlX3v2Ivn/rg7rm3kf0pycenUrYnHO6YXljoO2TP71bn33DsxNv48OXLNYdD27VW1/8lL75qtX5Nz+o+XceqMquWPKwfvb3vxu67DX3rteqjTu1quMEelifuuweSdKLjnu8XvecJ6e67Vbbdu/XXWsbHag3/c9NffPC/MWNdPmHHyzUVR/8vczC1csbvn5j279/7/PXtoX7X+fdpTvXbtOda7fpyYfP0t+/6tCp3/7v5ge0d7zRmf/mDY0O4gvGHqczfnK3vnvzA7r6H18xtex/XLFUkvQnX7lhqLrw/333dq3btkd/9fKnysy6fn//934tSXrLi47VhQvWaMuu/fqd448ceH9lsWH7Xn01OFl920vGNDHp9OnLGvXiqo07dclfv7Tn+m/6n5skSd+9+QF98vW/JUlT63/1muWhddEVSx7Wo3vG9aGLF+vEYw/XOdc1Tn5HR6bpxGOPiNzX54O88JFL7tRfvCD9fsz5QXt40n9dn2q7+52b7td5N96vpz3hEL3txU8Zalvn3/KAfrp4nW5csUlvmnNM3+WvW7ZB1y3boDc8v3+bsOzhHVPl8Y+f/SS9YOxxQ4W1qm4KBi8WPLBZf/CbTyw4NP3955VLtWbLbo09/mD9v9972tT3p59/hyTp+7c+qM/82W/nGqZXffE6SdI5163U+3//6bnuO8qyh3foG9ev0pKHHtX3/urFqWzzNf99vSTpwxcv0rnveIEk6exftl/ofMsLn6JjH/+YyG388ZdvkNSoqzfu2KfHzpo+VRe+7jlP1vMi6syPBxf9zr/lAT3nmMP1xrNv0obte/WmOUdr5mi8PvKNKzbq/25u1IvfuL5RNzT735L0Lz+6K3ad9r7/a5w3xKlbr1164PzkhCcdprcOWW8m8c5v3ypJum/9Dl1zzyN620vGupY57bu3a9HqrXrVbz5RY0cePPX9n36t0S9auHqrFq7eqvNuvH/qtz37J/SNt8/pue8/+UrjWJ/y3KMil/n7H9yhZY/s0LtfdpzO+MndkqRXfuGXXen65avv05bgIti/z79H7335U3vuOyo8u1ouNt63foduXbVZL3rq49uWc87poeAGoQ9dvFh/HqNtSurN37hZUnf++ctzb5HUOAdq+otzbo6Vz74QlKPte8e1auNOHf/EQ/usIa3Zslv/88uVmmZS89rQL5au18cubZS3v3zRgb7J6d+7IzTMw3r3eQu6trswuJCUttby3jQ+6XT0EbPavntXy3JX37te1y7boD87sZGP/+6ChXrMjO4656eL10lap2kmfeAPju/6/YLbGmMwr/nv7j7Zu759m5Y+sl2v+a0n6Tcee9DU/v/inEY+2bb7QN6QpD/72o36wCuf3jWuc9J/XacbPvLKqX+//VuN8p/WMbv1/s36zk2NC3FPOOwgffAP++exuF71xV9Kkj7x47v07Xe9MHSZM396d9u/P3v5vbp26XpdcNpLupb95q9W6axfrNBTjzxkqs/Y7ON/8apl+tuQYzSsc69fpVUbd+pr167Qh096Vurbr6NcJ/lzzp3jnJvjnJsze/bsPHddWknvuBzU3vHuK3d53BnjlE/8kti+d7B4j08MF5d124q7gzktzfyaVbbdNeAdbQ9sir6y2ktn/uw1eJxXWc3KoMHf4vEddDv2RueXsPiOBz31R/e0302wKaW7x9fFfDqi3DkpuV7x3bFnsKcWmsIG8iW13R1R8qIbS/NiShr1VHMLEUk75LZrcDBqKCrbPbqn+PZjb487cPPWzP+bdvS/0zSpzrvkhpG0nDaPf1nuuJeKbRfi3DG9fXcjLSd6BLTzp0GfAuy07JHuu5Xj7H8QYf3+8T533JfJIH3oZvl78uGz+ixZXXv2T2iiIx88GHIXbWv56HUOuSdkHKSfZvs1mSCjhy26bXe29WIedVmcpyNaRbVHm3c2zrd27UuvvepnfNKfp5iqIo0B5rWSWi8THh18BwAAAAAAAACosDQGmOdJers1vFjSNudc1+sxAAAAAAAAAADV0vcdzGb2fUmvkHSkma2R9K+SpkuSc+5sSZdJeq2k5ZJ2SXpXVoGtoyIf0arOA0jlUKXHtH2NyqCPddZBjaIqKdmxjXrNwjD7zuL1AmXVeSzSfN1MnG21LlFom1uWCifDYJYlCTAYDm9vReX/JH0jJ5drOH1Ik7yDQD1YT3EPe1j+IM9012POORodoAB9B5idc2/u87uT9P7UQoRaSaNBTLtRpZH2l8+HJuuw+Rz3MihTuW6GtUxhRv1knT/J//2RRigaeTBbwyRv9v1SDv6whknBut+o0H1zQjHhSKKYMtOyzzIkEkov10n+ANRDzfs8qJjS3FkKAEikLrU7zRjIA/4Zpn9pnG0VKrXyRLlExTDADHSo+xVhoCqSluVmR58qwB/cIQUA1cJAJ4CqYNwgOdqAamOAGUgJDUz2uJMUAACkha5bjkjs1NS5NxyWjTg9QKiYdQ5zXgHpYYDZc0VWOnkM5kXtIemEI1VQhVhMvTu22GBESxiwJEUg+/eRZruDQbdflgsrnbErst6IP+2ctyUpVV0Ts6S67RjLtC1UYL4oyeHOsuy0T7hYkgQpUNlSiEPaW1HJk+i4dC2bcd+koFRxLuofOew7wa57dcGy7zf2+50C388g2SxssbqltClsUr/2ZdzUf/xRRJFo3WdWu/csmROhmkofA8xAh8JmrKaC64skAgAAAFBnZbnBIy9VueEMKDsGmBHJCmy56jhxQZU6ChWKCgAAQKkx9AIG4KqFc612dRw78EWZU75K4y++YIAZkXi0CQAAAFVFTxdAYaiASqt5wYaBbaAdA8wAgEqiywcAAADAR9zQh6phgNlzVa9z0ohfVdKoCvHI/PG7ITefdPVkk02WW9nD35frPRmIdCANOh+XSjtt+nUmpybLrPxBaeiamMVF/5Z843EWObAQM4n3dyB/ph/i1m2WJT2KVLYTUx7R762o45l0jr9U6+h++ytqXpSIz7nsu7Ue7NdfGPC3NPTbPqW9v7b+R8wUC80TJWsL0tA9qV93P9+3VCkiPAXOV4qaYoAZSAnv8AEAAIiHk11gMLU+5ah15A8ocq4kH9GelAfHqtoYYAYAAAAAoAQYn2lXx/RgeLk/0gjIHwPMAAAAAHLFDXg5quMIXA0kKULcNQjAB7T91cYAMyLRDwEAAEBVMegGoCjUP+XVPHYMlgLtGGD2XNUnRImKX5GTqw3S2KczMUv5j3Xmk70MmUZJw5dk+cwnvKroRDpZau30dUYv0aRGKadN34lxmpOopbtbb3Ufm/RiHmdLeU5Y1Tsc5TjiWeZPJqNJpmxJxDHtrajkSVL3NCbOym8yzsLyTI79r57BKGzlGJuPOWExog3S/5harEcftw7i9Ot9S5ciykRbHvMuRVBFDDADACDe1QYAAAD/0WdtV5aL9J3KGWogGgPMQAcedQHqqdnJM7rt3qDjDQAAAAD+Y4AZSAmDUkC5lfTmBwAAUBF0RXrjfAsSd3ADvmKA2XMMeJQDx6mdb8nRfGwq6bunio5Hnvmqbu/lKvZdu8Xt20edjzWmmT5Rj0xGveu3yHKQ5Z6b8UojbbNMI8pGvXC822WZHr3KbaI5CeRy7psUo72NyDcUWe2O4ua32O9gDlmOujRcWV+bUXVRh4XDVQ0MMCNSHoU8ch8FTq426ObqNkAXJpNJnzyZgKto5K/hJJqwsSOt8075A4OBHHP4y/dJXeuAKgJFS5IHueMwueiBmP4Jn3Ud2nfC4oz2H7bdsvaXhkkjq/k7HYeZvLvftpKsk+QoFNGvaZuUtZzFBCXDADOA1GXV5Rm0Yax7JyxLPqds0scoySb+yeqQ1O1QN8sCeRwAqoP+bbkNM+BX6yMfEnkGT8uP6qwaYg0wm9lJZrbUzJab2dyQ3481s1+Y2R1mttjMXpt+UAEAAAAAAIByY2AcVdN3gNnMRiSdJek1kk6Q9GYzO6FjsY9LutA5d6KkUyV9Le2AAgAAAAAAAAD8EucO5hdKWu6cW+mc2yfpAkmndCzjJB0WfH6spIfSCyKKUtb3WRUhjZSqUnL7GpWkaVz0Mcl1974etMyEvcOv8f+sZyjn3bLtepWzYVMqzvq+vJ+u6PomrmzDWZJEwEDoV/ZTTPokmqPA5RvKovJM++SvQPbi9w2r8w7qrJEqQP5GYyxzlKTVLf9eI+lFHcucIelKM/uApIMlvSqV0KHyUpjjz5vGI+tBqTKo86RPmcfd36iXgs95p1PzWJcnxKijzMsUBSAGEgnxZNWHYGArW30n0uuR/l0/pXyo+h36rLJGlc63hkmi2r+vNs5El75VTwWEh4tlyFtak/y9WdJ5zrmjJb1W0nfNrGvbZnaamS0wswUbNmxIadcAfFP3Pg/KKaqzzgk0AADwBZP7oUoD7WU0dWrAYQDaxBlgXivpmJZ/Hx181+o9ki6UJOfcTZIOknRk54acc+c45+Y45+bMnj17sBADAAAAKLUyPVmC9HDNFmigLKCOyPbVFmeA+TZJx5vZcWY2Q41J/OZ1LPOgpD+QJDP7TTUGmLlFGUCq6IghCW7wAQD0wiA3yognq9qRGjUT84DHPQ+gOAHp6TvA7Jwbl3S6pCsk3SPpQufcEjM708xODhb7R0l/ZWaLJH1f0jsdLV8qikxGDmB8aRynKqW3r3FJHq5iY5Jn+ff1mGWFydz8lWb6xNmWL++nK8tAV5ahpGxUG8e3t+LSJ/6OnerRN2mNI/kWeYibz8KWI4uGK0PZLUvfD4grziR/cs5dJumyju8+0fL5bkkvSzdoqIWImj/pjNbwQ50byazjTj4fTpKBxqLvfG4GlWMOn2U/qSv6KXsdwTtEy2+QLFh0G1sm/Qbze72LOfP6od8kf53/do53R3cZ/CDVOiktXsrFTd280rKIJrt1n770GeqcdesgrUn+UEEUfgyKvINy8qTnhSk8DAUAw6MmRZ1vAgEA5IMBZiAltb6SDAAAAAAZ4nwLPuFJHKAdA8yIxHVuAAAAVBUPSQAAkqPxAMIwwOy5Qqsu6s3Y0kiqKj0K7mtMkqZx0Yckz90XHdcs9LrLpYLRLa3OvJfmY7xJt8Xkj/1lGc6SJAEG1PVOVo54m+ImtEuy7PBHLVEdUlCiuIjPQNGa+bH1fdZl6T/krUrn1lXCUak2BphRqKgKJlH3NeVaisZocHWe9KnOcS+DMqVfMy+VKcyon8znj6IA9EUSoWiUU39lP8df7z10XTwmr3QZJk3q/mKGWJN3Zx+MRIoYY2jdJxd1kQcGmBGt7i0XBkbWQTmF51xOigCgmnifa35IawB5KkOVwzkGqoYBZqCD0QP2Fo0w8kANAACoEp7Oq5ZBjmaVs0CV44bsFfp6tOJ2DWSCAWbP0WCWA8epnW/J0TyxSnqcio5Hnvlq0Memyno9JvxkO58Ep75o15n3WtMnq3d9uohlqvr4YDNe6eS97NKIslFtHN/eikqfRK9EduXomwy939Z2weOMW9IuGELEzWZhy/mbQ7NhMXN+HulS1vMgH3lc1SIBBpgRjUKeyLDtC8kNAACQH05ogXKp0njeMNVP3Qc2Y8U/y0mJaTuAUAwwI1Ie9Wbk3WWJ5vhLN6Q+36mAQe+yzb4Xlv2EV+TLpFrvcChT8h2427REgS6Zup2XNctCmlVh9hObkv/7oYpA0eKUU7Lp4PqV8V4/Z92H6L951+NfkIY7RnUfYC5j+1d4mIvefx91z9NVwQAzIlHGMSjyDsoo+nUKnvfIAABAbdDPBgD4iAFmAAAAALkq/G4uFIKLtgBQXzyhWW0MMHuuyE4YRT++NI5TleraqkSl6AYwz/JfpfwXR5HR5eS6XWfeSzN14uTrtuNR5EziJckWWYaz6DoX2fKx7vPpkdws83/vVymkuLEe4k7M1barEkx8WBZVjFOVxK0fw5aj7SwxDh0qhgFmSBqs01dVebyvF+VE1uhWxbqjsw6oYhwBAH6irwGgH/qm/eVxUZOjkAEawVJjgBmSirurJOqKa5LQpH3RlqvAg8si7Vq3WPSh6bX/7Ce88pOPd6SFSRLOznycexzLkaSovaInkEJZ6l+f+ZjPfAxTpDhPibjmomWKmB+i0ixOSmY++XS/3zufTsr0Dv1y5q1hQl33MThfztcTjVlkFooe+yzwIb2Bj5EnxxaDYYAZkerabhVVpVWpo1ChqKBGosog/RwASF+V+j2+8ympufMyPUlSklT3D/1L1LFg8rR4tTHADAAAAAAAAAAYCAPMnivyyiYXVeNL4zhV6Sq2r1FJmsZFxyPPPFF0XPNWaN1at8TuozM58n7sscjHB1uV5RHfLENZjhQoli+PBQ+ixEHPRVHJk+wVUjlPQJzbnjr225JZybfIQ9x8Rn6Mj7QC8scAMyTxuBoQB0/0dKtD3cFxBwDkJYs2h3EWkAeqha5pf6UYYC5DGPPGiVepMcAMSQVO8hf1fYIWoSr1cpnvSmqq+kR3PSf5yzp0RUc+QlnuuhwmmHkXzebuKlAloMKqXt+XQdnriLKHPytlSpd4k80VPHFuiQ2TFzKvo/vsoOvppOyCUlpDpUnNB+F8yU9JjkIRdXtrfVvkE4Lt3/cJR5kaQXRhgBlA6urd5UHZdU4+QT8HAIDh1OGJJyCJKtxc5LMsx+A5ckC4WAPMZnaSmS01s+VmNjdimTeZ2d1mtsTMvpduMAEASChhx5J+voc4JgAAAADgvdF+C5jZiKSzJP2hpDWSbjOzec65u1uWOV7SRyW9zDm3xcyekFWA66bQCYcYbUlk2KukVUrtrOIybJ5M+lhmnYrAoGlb1juSwmKb1+GuUbaKpTPvpZk+cfJ16xJFtntlqW8SvcIqYaTKkgZFKnMalTjouSjq2CbZr5PLdwJiDzKNj6/08CFditL5lJlUjfSIG4VmXC3kO7SLPXFigWXcx/oFGEacO5hfKGm5c26lc26fpAskndKxzF9JOss5t0WSnHPr0w0mslbWQSIgTzV/3VmoOqRJHeIIAPADbQ7iIq/UV52Pfdy4M3hbUnXO3BUQZ4D5KEmrW/69Jviu1TMkPcPMfmVmN5vZSWEbMrPTzGyBmS3YsGHDYCFGJgqb5C/y5e9JtpFu2LkKPLisk67oQ9Nzkr/MJ7wqOvbhylJehglm7pP8BTv09ZgDUg71fVkqlwKVJYU4lslkkVxZHYJY2+XwD6xf0vVO/46ng9I+X+r3e+fTSeQDpKiM+amIfn1rOhU1aXnyFUt4cDElrUn+RiUdL+kVkt4s6RtmdnjnQs65c5xzc5xzc2bPnp3SrpGVsEeQkKEK1aXkHJRRVL5loBcAAPiCUzTAD8OOlzCWiqqJM8C8VtIxLf8+Oviu1RpJ85xz+51zqyQtU2PAGUMqstKp6x0ng7QTnUlV06Sb4lv0p+4ITRiwouNRt/cc5qnYd+3WLLH76EyNNJMnalNR710udN6DTLc9WB0Yvq3scDGnv1KnkId1n08h8u1pwqhl8wylD2niYbb1AukyvPZ8Fi9Bw8oEbWe4LPMoffn0kaTVEGeA+TZJx5vZcWY2Q9KpkuZ1LPMjNe5elpkdqcYrM1amF0wUgTKeL9IbSBc3+ACAv+j31BODCMDw6OP2R1UD5K/vALNzblzS6ZKukHSPpAudc0vM7EwzOzlY7ApJm8zsbkm/kPQh59ymrAKN9DHJH6osrde98EhityqlSVRHlPqxOFmdHNTtiDbzcJXKK5AGH4tEVctpVeMFFIFXWfZHCuUjrb76VJYmb5faaJyFnHOXSbqs47tPtHx2kj4Y/KGECnsEzZNttG1v4A1SGWY+0V3Bl6KLfWVNcfvuxddwdRrmUba868fm3sqStqinrB8PJfv3V5ZHdMsRSn+U5LBKitc+lig63hkmLxQ9+XTX669SyglVGnvi1Rb1UkTd3vYaltz3PeAey9QIoktak/wBwJSs+n40NygC/RxgMJQd+K4uWdSHeFIfpGeQtCT5URWp1yUUDiA1DDB7jxqvDLgC3c631Jia5G/A9YpCvqomjmq7rmKW5iR/EdtyUZ8rOrFuqpP8ZTvLH/ooul0aRnlDnpOCEihJX8Mp3zxYVHZvTRPybQQSJlVxkzOsTJS4WchUHslSoRvqC0c+rgYGmBGJQp6vMp805oVGHACAaqBNB4ZTpddFIJk6H/q4+T72qfUAiZnWWTtn/6gaBpgRKY+7J6MGVZOMtaY9LltUZ22yAi2Mr3fc5jERBu8j9Vucw9NcpugTtmY4uOaUnbqdmGUxyV/m2ZP8Xxk+12U+h60M4rWtJPKghulXZ53q/bbfedjJBt2GSZOi+6pFIzvFk8dTenGeFoyjiDxNvZQ+BpiBDlQ0/uLQIIm0LiyQ7wAAAJAmzjlRBb7eYIZiMMAMeKJKV6IrFBUABeLON6C6KN058qgu9Sck9eJRFgCGRv/QH1biM/8qjb/4ggFmzxU74VBx+y4b54avoKqU3r5GpWydkTyDW7KkGRp1q09cx7/SS6A422o9HkUemrJkC+b4K1aZ06j7kfniY+PTyWVRqZHstXSD19CDpLUPaeJBNvVSUeniUZFN1TDpSRYF4AsGmCGp3FeegLz4dCLqizqkSQ2iCADwRB3aVQDD4dw9juyH3qmvM0CilhoDzJAUfpdXsXdyxd972u/9GXR77XfBJd9GFd5flMXdDK13OBV9t1Ov3WcdNF/voPE1XJ2SBLPrLrtUQxJj/1P/L0niopZiTe41zPbJ/32Vp/4tSUA9UZbjKsUr4yWKjneiJ89yPX/v91sa+pXrrPrsYVstU5lpNVTdyBhcegY4DIPkubAykfkk8a3n0RnVxlHbHThqORbostYdPmOAGQCAXuh8AEAlcXIJAACQDgaYAU9U6VGn6sQE/fj8FFPSoDXj4nOc6sY4GAAAtGmeM9BEoo7I9kgLdWj6GGD2XKF3VnBXR2xpJFWVHiH1NSZJw1X0nU157r5K+S+OQuNbr6Tuq3vir+y2HbFUy/LFHZw8dp3GPrJMo6Lr3DIocxp11rsljkomsjy2aW3aKec8WFCGd22fq5FT045FmesiP8VL0LB051iEI12A/DHADEnVunsWyApXObtVKUkiO6JVimTJFP3edQAZoniHqnpfg3odGF7Fq4m+sp4HAtnpe+yq3ghWHAPMkFTc1fnIySsSzciVSlCGNmxdWIX+dgWi0FPPyVSy3renqetnqLoNVb5yjmTz5LsKdQKqK/uJaTLdfCX42i504lgmU6b0ilMPlCk+VZJ1/dBv652/p5UPqjT0NEya1H0Mzpf2L8lNekWEuO1pjIwC0G8y0tQ2mAHap/QxwAx0oKLxF8cGRfClEwsASFfdB2nyRFIDyBN1DpA/BpgRiUEVAAAAVBUXrgEUheqnvNJ6ios8UCwuMqePAWbPFTnIW9dO9yAVTRqNTJWS29e8kzRcRV9kyfM9hb4es2H0Ksu94pt1Z6PofOWbrsdoM9x26DItCxV6ZHKZ5M/vvEfZ6K/MadQ1oWcxwfCWb6+ri1o2z3AWlUfa2gUyaijf25OyiZuczfLX+mqGMrcLWSJVgPwxwAxJTPIHxMFVzm51SBLqR2AwDEDAdz4OzGTR1/ChKHoQhMoYKN/6kAky4mM5zhrnJP3RBykpMnepMcAMSQXeNRGx3xLO8Te8KkSk4g15z0n+Mo66r0nrabC6DFPH5V0/uo7/Az7KfGJTCkBfZUmjqGByChmuLMdVivmUSOahqK5+A2S9LoAX3i/temKBnNCFJBlYmerJpkLCnMvTccm+7zt+zBO8pcYAM9CBisZfdE6RpagTOeqE4pD0AAAA8BJXSoE2DDB7joGNcnBKoX2pVAPlV8Y9MHCYLFxFl788d+/XEctekce26Hzlm673sqaYQJF3VUR8LrIgZHkBrbntNPaQZf6lbPRX5jTK8n3rVVDUsU1W97ihD1yivZUiTZCnqj49HzfHhZWJMrcLWSJZ/JT0jucsVbU+KVKsAWYzO8nMlprZcjOb22O5N5iZM7M56QURRaFSHtxAFSQJDgAAaoL3Y9YL5/FAu2EuZDAwVixaLyBc3wFmMxuRdJak10g6QdKbzeyEkOUOlfR3km5JO5DIXtg7vOj454u7JbJjKfXC6Mx18zlJ0gobx7166nZImagSKA/aHAD90K5XA8MtB0y1fTSCpRbnDuYXSlrunFvpnNsn6QJJp4Qs90lJn5O0J8XwISeFTfIX+YhE/PCkXTEXVadVoYGpQBR66jnJX8ax9zVtfQ1XpyTlq7PTnnvZZJY/lEHWE0hlu/lKKEu/oSzh9EUW6ZVZHyXGZrlhZXD9kq7Xcc36lTT9w5Zs+ToiTQZXxqQrYryldZ9Z1cWpb5VJ/kotzgDzUZJWt/x7TfDdFDN7nqRjnHPze23IzE4zswVmtmDDhg2JAwvkgYrGXxwbFIFsBwAAAABAtKEn+TOzaZK+KOkf+y3rnDvHOTfHOTdn9uzZw+66Fooc2GBQJT4GPttllR7Dbjfp+kUf1zz3P+hV7bI+xFTkK2moLtp1Hot006f/1lqzfqH5Ioddp7GPJGmUdHeUjWrrmtCzmGB4q6j0SFIvuOHn+EukqLuf29qFojuDnvLp1X5VOERx41CBqOaGNEU/vI0jfXEGmNdKOqbl30cH3zUdKum3JF1rZvdLerGkeUz0Vy68xwnoj0aoW1rvt/ZBVAezOjEsnyqcNAJAEhVqVpExzt/qq871hFm8/iFdyJKqc+augDgDzLdJOt7MjjOzGZJOlTSv+aNzbptz7kjn3JhzbkzSzZJOds4tyCTEyA0n9slUaaANAACg8ujrAiVTnfMtqp8S4+ABofoOMDvnxiWdLukKSfdIutA5t8TMzjSzk7MOIPJR2CR/Cb8PX7YaNXwVYlH1ixI9J/nL+nFKTxPX50dH07rok/8cf67t/4CPss6dPtctvihPCoWHlEMcrkzpEqedYrK3wQ2TVFnXoX0n+etYgMPejXZucGXsIxdxuNtfA5fVPpK18X2PHZP8ldponIWcc5dJuqzju09ELPuK4YMFAN3K2JlA+XECAAAVVZ2bIXvyoRnjSb9i+ZAHgDxR4wD5G3qSP2SLzkBJpDFxUoUOtq8xST7hVNGz/FVyV17oVdyyPgeuUllPQ+fd/2kmT6x39LUsVOShyWPXaewjyzSibPRX5iTqntCzxJHJQGET2iVcNtcJiPPbVaQyl7kskSzpilv+w5aj7QxHqqAfrnumjwFmSGKSCCAOGqFudbgjqQ5xBAD4gSYHQD/0Tftj4L2kyNulxgAzAAAAAABACTAEB8BHDDBDUoGT/EW9/D1BcNK+OJnKI8QpbKOMsshHrVss+kJ0z0n+Yi438L7T32QqynJ3QJJwdi6adxybuytJ0qKm4pSLYfIw2b+/8tS/RYegBw/D5nV6dYgV1qk2rUQR80Qa50lZ6Xc8uyd3zC7QHiTHQMoabh/4UAYkJTqIRQS5yPPogccFvDm4GAQDzECHouo0HnUCihVVAunmAED6eD1bfuhiVlOS40oe8A/jaKgj2v5qY4DZc0yAUg5pHKcq3dnha1ySBqvoaORZ/ouOa96KjG7Nkrqv9kn+0s33CW6u6wpL3vKoN9PYR6aT/GW36coodb+w8+mQMsclA1mmRs8nsBI+4VOHvknb5K/FBCF1Pj7xiQPipmdzudYLBnXrwwPwFwPMkMSVJB/QN/Afd390q8Od99WPIQDkj0GRcJVvVjnuwNCqXk2kgTbGT30vUla+Eaw2BpiBDtRpQD2F3RUCAKgw6vvc1OGCNAB/UOUA+WOAGZIKnOQvcr8JHtdLJygHtsfVzoFlnXZFH5qe8cv4cUpf86Wvr0PpNEwo847h1CR/Oe8XSCLr/FmSqqVQZUmisoTTF2XK+3HCmvU5Rln6IYPol3a9X32ScmASbr9rwuTsglJapMngyljuiwhy22vocs5xA8e3hMcWBzDA7DvKVylQD7bzLTmanZCkDWvR8cg3XxUd25wlmfU57fcW1iyp+2ktl27qPyltOyKxo967XOQ7YTN9/2qq77XmJcxFKnP9UeKg56Oo9w0nWtblmgeLyjOdcwP4xo87Mz1MmBKLm8/CluNIhGPOiHLxsa5FcgwwA56gUgWKRRn0D5OAAdXlRZ3rQxgA1NMQlSCvnOmPPiSQPwaYIYlJ/lASA/YT0uqE0Zfr5nMHN62QeRxFDKhuh7SoNp6TOyC5LNocLwbzkZpBjmeV6+Myvi5hWHXrx2SpjvknTWkl31Tbx4lXqTHADKSEqhAAAAAAssHYEwD4iwFmSCpwkr+I3Sa5EsZVR39kPulTwXdf9JxMpW259MNJPh9OkuTrPHfJO+mb+ZxjDp9lnz3J/32VJImoy5IpU3LFCWr3ZG/pRrBM6ZVUv7j1GmzNfnLFPr937L/Kx2lQJMlgTFbS/JR/oNvmOcn9fCbi+37hKOfBRYABZs9RvMqB49TOt3ZhapK/pOEqOB557t63Y5a1sBOvqBO1tJOm6AslvmmfTCnd1Ins3LZ9Lq7z3SrbyWgGrAPDtpVDOBGtzCnEQHNvvt3sEbVsvn2TgtKk7TP5Ngypkq74+ax7OarWcKRLuRR9vOijpIMBZiADVFAAAADRvOgr8bh9bkhqID28KqS/TC+I+9B+AR5igBmSmOQP1cYkfxgGhx1lRxsPRPBwjCCTSf7S3ySAQtGul1EVzyXTesqDSf6qgQFmAEA1JeyfcDOCfzgmADA87rYDWQAAkDUGmCHJv/eLJQlN+h0mv9KiTLLuvBbdOe45yV/re2Sz2HcG26yTOHVc1DJ5p30zL3HM4bOiJ5CCf323KOUIpT/KlPfjDFxn3jfMdvOFGiZuRffJu36v8oEaUJnKum/KmHRFHO+sz09773vAPeaYUJTB9DHA7DnuOCgH5xxPc7TIKt8Ou9WkwSr65D3P8l+3miZR0qZ9HOqW2Ak4pZvcUdtq+77AznerPOqbNPaRZdGhy9NfmfuFnUH3ISY+hKGpuEMbf8fODZ4HfUrrftonny0uHFF8CFNRfeSw0y0PkmN4MSMRduyLPl/Jm5OLVQbipkue5YnhAn/5UK9WQawBZjM7ycyWmtlyM5sb8vsHzexuM1tsZleb2VPSDyqyxPsZW5EWCMdFhHroemc3Bx4AkBOaHAD9UE/0x4BhSZG5S63vALOZjUg6S9JrJJ0g6c1mdkLHYndImuOce7akiyX9R9oBBQCaGwAAgPJi0AcYXp3PidK+MW6Q8cxBq7G0Jp5Pvt/stk2djlZx7mB+oaTlzrmVzrl9ki6QdErrAs65XzjndgX/vFnS0ekGEwAAAAAAoPzq9moLANUXZ4D5KEmrW/69JvguynskXT5MoJC/ohq4qPe4FXsljMZ+UJlP+pTp1mPsv9ckfy2hyyL/+np12Of3gbbe4TBUMHOOY3NvHictwMRdHihLHVGWcPqiTH2IOJtt9o+yuoHO537I0IaIW9c7z9OeTqLfJH9d/67wcRpQlbNu1sqYnwqZ5K/A/Q+8Oyb5K7XRNDdmZm+VNEfS70X8fpqk0yTp2GOPTXPXlUWeLweOUztf0yNpZ6ToRifP3Rcd17wlmqiswH3XQedkSmlerIm8iNm6j4iw5C6HfacSvwzDWbd6aBBlTqKuAacyRyYDRaVHkv3GnVwrLYWlSUQb4QsfXlFK+U1X3ORsLteaBzgW4XxMlqKKrgdVhvd8zC9lFOcO5rWSjmn599HBd23M7FWSPibpZOfc3rANOefOcc7Ncc7NmT179iDhRUaY5A/oz4cOvW+KepdYnqofQwCAL2rQrAIYUt3P3WMNqns4YlhU/V6q87UyhRVd4gww3ybpeDM7zsxmSDpV0rzWBczsREn/o8bg8vr0gwn4r+4NPQAAAABkpVQDZUANeDiOjwL1HWB2zo1LOl3SFZLukXShc26JmZ1pZicHi31e0iGSLjKzhWY2L2JzQAnQcQHqjBoAAAAAAID4Yr2D2Tl3maTLOr77RMvnV6UcLgTyeqdScZP8RXyfIDzpp1HyDXa9NzTN4JSJ6/h/Gptsez/rYBturpd09STvi2wLZ0oJ0L7NbA0a5rJMrtN9LKPD3T0xTcph6Tcxjstmv75qrzvTfb9n1KY63/vcf43sZbnnZhqn8wrm9LbVve2Wz3UpAAnl2S6kJU4b7Jwr5M5En9qwLCd47dXGJ5qTYICJ44aJT5y+SSZ1kSeVUZw2LOm6ael7bDKaZDCszHpUjBOJ7ovEW2fqu7bfi6lL8xbvDRnxEnWQ/DPQOkW02u2VWXG7TrJ8npP8tc374sRtRsOL84oMoFbK2kmpAw4Nkkirf02dUJwanCMBtVXUzQ115FM75lFQaiXvi+Xob5gkrHP/KG7cfcyjRb1S06fs4uFhQYoYYIYk3h+MakvrSn6dO3NR6nCXRA2iiIqjjYePfDj597EN8zBI6ShhvCp7LFB65M2SKmySv2L2m8RUGMsQWERigBkAAIlL6h7yYQAKAAAAANAbA8yQVOA7mKO+TxAcHrH0R9WPRM/3R8ZcbvB9+5m6voar01DvgMw9is2XMJcjbVFTGWdP2vb+ylJFxHpXZknikodypUUx70hu236p0iuZ4fouxSZMZx1e4cM0sKKPUamVMO2KCHIer5OPzMeD7i/PdzCXLxt5jwFmz5Hny8HJ8Qhyi6zy7aCNwLCTAxYlzwGWujWwiSY1Svk4MHDWrnOSm1RTJ0aft32CjzR3nkyW+56amC+FfWQazrpVRIMocRJR9/VWVP4feCKmHBRVJRQ3LVZ5FHVsfHytTRriT0gXNsufH/0Y35AU+UgrnYvOu+SXdDDADACANPVetGqeugCAX3w4mavLRY16xBK91CWv1wU3NvWXZZ4f9IJpUUcty/xCTkQrBpghiUYK1cYkf9nx+U6StEJG/YiyIw8D5ZFFs8rg4mCoOeEtMmcpFXbaVIL8wiR/1cAAc0nRUQTgA+oiAFGoHuA78miOSGtkhbwFAF5ggBmSCpzkL+r9mEkm+aNT4Y2qDzb2nOSv2lGPVJ5oDx7SvOvHZl4qT9qijrIuF3WtU5MozTuNYwSzJDHJRZnyfpywdi6Tdl+xNOVgAMPELfPJFfvsIevjXgUkyeDKmHRFhLlznpNM9hH5/cCTJw0clsS7ym1P9cEAs+dojPM3UIpzmNpklW8Hn4x2sAmuCj+sNZhIpyih8U3hgtfA+66xzuRIs/6I3FLEhDhFHposB0mmJvlLYR9ZphFFo78yD6b5WPf59CRuUcmTpM5tTMQ6YEgHSOvCsgyTpvVFuqQrbnr2675yWA4gLXKSUkIXXacUvf+qYIC5BHzq/AIAAADD4mQOPuP8Cz6re/Yc5OkJHxQ1J0ame617ZkQbBphLII8yywRABwyaEq0dUR8btDpjkr/sVDJJOiLFcUfZ0cYD5ZHJJH/pb7IWfJ7IuK44Ig3kzWINeq5f1GErQ3Zhkr9qYIAZAABxAg4AdVObGwLqEk+gRMr8yiMACMMAMyQVOMlfxH6ThIem2R9VP1HrOcmfsn1fn69p62mwJKX3VEHead/cna/HHJCyz59k//7KUkfECSZzjhxQpqSIF1QmBB3UUHEruI7uml8hq4CUWJXzbtbKODhfxPFubVszS7O057DJc5K/8mUj7zHA7DknHoHJ2yD1DHVTu8zSY8hWIGnDWnSjk+fuy9hRG0axk7mhVVvn16Vb7qIGraImxClykCuPXaexjyzTqOg6twyqlUaViszQijq2SXbr5HINpw9pUrf+UVxcFEpX3NRsJruFfNf4zHFp8jElihrVyfJVaT6m8yCo69PBAHMJhFUHabcdvJ8RZVB0tc+1nm5VSpIqxQXwAZ119MI4SLiq9zXKcthN9AvKoo5tTdXriVTEbGTyzD1F3TiY5W6TbrrvRRAyd6kxwAwAgMpz0lsn3IkDAAAAAP5jgBkAAABA7dTlRikfLtXVJKlzlST/lvF6bV3KJ5IxFZ+fS1icgFwwwOy7nGqvwib5S+Gl8Gnf4TZIX6boRs4Xvk5O1swjScPVNUFJr/Vb33+WUnlyGWwzzr4SrZduMDLTFb8eEe6sA9LOz/3qrKn8WprUHU6W77qM2lrU+wqr+m7uNNPVdfw/Xa3v465H/k8q6v3hPjvQBkeHuKi4+JXNBuurxNpyr7RP1OfufG99vHUG5cP5SZF5ZLg5/jLuN/b7vSPh0krHKg06DzIHRNhxbZtofNhAlUScePqWFkXUZ0nr62H3Eef7yO0UMpDQPg8MhscAcwlUqSEtA+oWf1HxIwneLQ8A/qJJB8qLPvnwhrmQSg+3Px/zaHGT/AH5YIC5BPIYJGEgBlWW1oQKXOzpRpIA/qONB8qDvoYfzIxjAW8VNVkchlTQYStDfpkKYgnCimixBpjN7CQzW2pmy81sbsjvM83sB8Hvt5jZWOohBQAAAAAAAAB4pe8As5mNSDpL0msknSDpzWZ2Qsdi75G0xTn3dElfkvS5tAMKAAAAAAAAAPDLaIxlXihpuXNupSSZ2QWSTpF0d8syp0g6I/h8saSvmpk5Zmjpsv7RPbph+cbYy6/Zsiv0+x/esfbA51+viVy/12+tFq7emsp2krpn3aOh319z73ote2R7rG1cefcjesKhW1ML0+ad+xLH97I712li8kB2/8mih/SYGSOJ951VOme9/+Z6963fIUkan5xMLS7jLel659ptA2138859khr5asWGHbHX2xKs17Rnf3S8WvPrjxc+pJmjw7+BaOuu/VOfF68ZLO5xrdmyu+3fcff10LY9hefbVq1hue2BzVOfV23a2fbb5l3tx1aSfrlsgyRpxYb2Ze9uqafSiOvP7npYjzt4RuTv67btkSRt2bnfq7TNyv2bDrRzP174kHbsGZ/6d9L81bns+IQLXf+2+w/kjRtXbJr6/HCC/aV9bDZ31Ddpbv++9Y36aclDw9cjzXBOuvC0bbV3fHLqc5z9Ll6zberzbfdvbmtX0bBz74HycceDW3TwAH2NvO0PjmNn3dqa5y+9Y61Gp+X/WOx1923wpp5t5v8HN+9KPUz3b4re5nX3bdC6bbtDf+t0zb3r2/q3t6zapL3jEz3XadbjjwZ1+/zF63ToQXFOQaUla8PPE1r96I61mpGgzxUnbe99+MB+lz68vbA8ErXvtVsbx6tXf+L2B7a0b+uR+PGIs9wvl67vuU5n9X3ZnfGPe1PYSMKVSx7R8vXtffmd+9rzYJbHK800XLFh59TnXy3f2NUPCHNfR9wl6d51B85BwurSrNIjbLt5lJWbVm6KVebjpKfUqMf6hbvz931B/2be4odit8MPbooY18kwHRet3jr1+YEe7cAwVm3cGbrd1v5Kq86+QNPCIKy3rNwUmqZZhP2hrXumPv944VpNH4nfljznmMP1tNmHpB6msrN+Y8Bm9kZJJznn3hv8+22SXuScO71lmbuCZdYE/14RLLOxY1unSTpNko499tjnP/DAA2nGpRRuuG+j3vrNWxKt84wnHqJlj8QfFAOQnqfNPritAwj/zBiZpn0Tk/0XBCKYScc9/mCt3EhZBwBIsw+dqREzPfzonv4Le2rG6DQ98bCZWr053gUElMeHXv1Mff6KpUUHAwk96zcO1erNu7ouimTpMTNGdMwRj9HSmDfvIZ5PnvL/6W0vGSs6GIUws9udc3PCfkt2GXFIzrlzJJ0jSXPmzKnlbSnPf8oR+uWHXpFonScedpB27ZvQNJMeM2NUKzbs0GNmjGjv+KRmjEzreg/6xKTTxKSTmXpehRmfdBox0+iIRd4ltHPvhA6eme3dMUccPEO79k5o9/4JWRCu6SPx7mIZHZmm8SEGlvaNT2p0ZJoOmj5NTzj0IK3auCP2lSvnpCMeM0M7941rfxCGTTv3adb0kcR3L08fmTa1jSI00yHpzUO7909odJq1pdnjDp6hrbv2azLFBxgGDV8annz4LG3ZuU979k/K9Znz/vBZM7Rt9/6+yyUxfWSaDp45qq0hd9ymbXRkmmZNH9H2Pfv7LjvpGncwFnHHWWsYTNLYkQdr5YYdGgkJy77xST3p8FnatGNv129POPQgbdq5V+MTTvsmJjVzdJr2jk+G3n0+zSyVPO1c9NwVE5NO04JJhY48ZKY2hoS5qmZNH9G+icmptmjSSfsnwo9Fp0nXTDtN5YGJSacnPXaWNu7YG3ncpo9M077xSVnQth560Kge6TOQ4Jw0fXSaJiddqnVc0zSzqfY7bTNGp03dcTOsJz12lh55dE+sNNi+Z1wHzxyNXX8fMnNUZharHqqzQw+aXpo0mmamIw6eEVoP79o3oVnTRwqZ0+fR3eM6bFaup0J9jUyL7pMPwrlGGWyN5/ikk0k6aPqIRkdMu/sMdEy6Rlt60PQD9fGM0WmaMTJNOyLuUGuud9hBo23LRLWxvRz+mBnaPzGpnXvHtXXXfh02a7pM0uMPafS54qbX/on2dqKfIw6eIVP8uyDTdND0ER00OqKtu6P3HZWWs6aPaMfecY1MMx120HTNmjGiBzfvit2ejk9M9r07tNmXGR1ptIdh7dY0M/3GYw/So7v3a+/45EDnOc5J+yYmtS+I6/4JF3leumvfhKaPTNPINMvkfGFi0mnSqescdWLSaevu/Tr68Fk6bNZ0rd68K9Ed9dNHpmmaWd8nAVrNmjGiJxx6kF5/4lEanWbas7+xbmdftfkx7fq1+XRp6znAjr3jMlnq4wbjky6IR6OPPD7ppvLyzKCMHDxjVJPOTaX7bxx2kNZt26P9E5M6ZOaoHt0zLpN08MxGPbhl1z49ZsaIdu+bkJMiy8a+8ckgP3VP+NnMm811nZOcpGnWOA4zRxv148EzRzUx6bR3fFLTrHHusW98Ult379PGHXt15CEzu+IrKdXzq8NnzdD0UdOG7emfV/Q7P2r+fsTBM7R9z7h27h3vWRdNTLquOtpkmnAus3GAg2eORt5t3csRPZ5GrbM4dzC/RNIZzrlXB//+qCQ55z7TsswVwTI3mdmopIclze71iow5c+a4BQsWpBAFAAAAAAAAAEBWet3BHOfy2m2Sjjez48xshqRTJc3rWGaepHcEn98o6RrevwwAAAAAAAAA1db3uTDn3LiZnS7pCkkjkr7lnFtiZmdKWuCcmyfpm5K+a2bLJW1WYxAaAAAAAAAAAFBhsV485py7TNJlHd99ouXzHkl/nm7QAAAAAAAAAAA+SzbLAgAAAAAAAAAAAQaYAQAAAAAAAAADsaLm4jOzDZIeKGTnxTtS0saiAwFgIJRfoJwou0A5UXaBcqLsAuVF+UWUpzjnZof9UNgAc52Z2QLn3JyiwwEgOcovUE6UXaCcKLtAOVF2gfKi/GIQvCIDAAAAAAAAADAQBpgBAAAAAAAAAANhgLkY5xQdAAADo/wC5UTZBcqJsguUE2UXKC/KLxLjHcwAAAAAAAAAgIFwBzMAAAAAAAAAYCClGGA2s2PM7BdmdreZLTGzv2v57XFmdpWZ3Rf8/4jg+7eY2WIzu9PMbjSz57Ss8y0zW29md/XZ70lmttTMlpvZ3JbvX2lmvzazu8zsf81sNGL9b5rZoiAcF5vZIcH3M83sB8F2bzGzsZB1n2tmNwXxXWxmf9Hy2/lBuO4K4jI9Yv8/M7OtZvbTju/jrv+OIF3vM7N3tHz//CBdl5vZl83MeqUj6qvAshu6XNQ+Q9Y/PcjfzsyODPn9BWY2bmZvTBjnTwZxW2hmV5rZk0PWf0pQvywM1n9fy2+fMrPVZrajT/w/GoR/qZm9uuX70DoN6FTishvavpnZY83sJ9Zok5eY2bsSxvnPg+8mzSx0Ru0+63/ezO4N0udSMzs8YhtR/Y7jrNFfWG6N/sOMXumI+vKw7PYtO72WM7PHB/HZYWZf7bF+aLsdp+x3bGdeaxzM7AwzWxu0yQvN7LUR61F2MbQSl9/QNs7Mxsxsd0v5OTti/aHKrzXOeZvLnG1mI73SLGR9znkxFA/Lbtx+Z1TYjgjWW2xmt5rZb0WsH3puambvNLMNLWX/vRHrXxu0nc3lnhB833e8LFiOttc3zjnv/yQ9SdLzgs+HSlom6YTg3/8haW7wea6kzwWfXyrpiODzayTd0rK935X0PEl39djniKQVkp4qaYakRZJOUGNQfrWkZwTLnSnpPRHbOKzl8xdbwvk3ks4OPp8q6Qch6z5D0vHB5ydLWifp8ODfr5Vkwd/3Jf11xP7/QNLrJP204/u+60t6nKSVwf+PCD430/NWSS8O1r9c0muKziP8+flXRNnttVzUPkPWP1HSmKT7JR3Z8duIpGskXSbpjQnj3Fon/G2zHuhYf4akmcHnQ4IwPDn494uD7e/oEfcTgvpqpqTj1KjHRhRRpxWdR/jz86/EZTe0fZP0zy3hnC1ps6QZCeL8m5KeKelaSXMGSLM/kjQafP5cWPh7lVFJF0o6Nfh8tiLaff7487Ds9i07vZaTdLCk35H0Pklf7bF+aLsdp+y3LPtnkr7XGgdJZ0j6pz5xp+zyl8pfictvaBsXlMme+w6WG6r8Kuhfq9H2X9JS5vr2HcQ5L38p/HlYdvv2O/uE7fOS/jX4/CxJV0esH3puKumd6tFmtywXWrco3ngZba+Hf6W4g9k5t8459+vg83ZJ90g6Kvj5FEn/G3z+X0mvD5a70Tm3Jfj+ZklHt2zvOjUaqF5eKGm5c26lc26fpAuCfT1e0j7n3LJguaskvSEi3I9KUnC1c5YkFxLmiyX9QecVUefcMufcfcHnhyStV6NhlXPuMhdQo+E7WiGcc1dL2h7yfZz1Xy3pKufc5iAdr5J0kpk9SY1G/OZg/e8oSHOgU0Flt9dyofsMWf8O59z9EZv/gBqd1/UR60bGuVknBA7WgTqhdf19zrm9wT9nquVJk6DcrYsIV9Mpki5wzu11zq2StFyN+iyqTgO6lLjsRrVvTtKhQVt7SLCP8bhxds7d45xb2ifsvda/0jnX3F9b2rQILaNBmF+pRn+hZ/wB38punLLTaznn3E7n3A2S9vRZP6rd7lv2JckaTxl+UNK/9wtrCMouUlHi8hunjeu1/lDlt6V/ParGQFPYOXdU+eOcF0PzsOzGLZNRZeQENW6oknPuXkljZvbEkP3EOTcdRN/xMtH2eqkUA8ytgtvjT5R0S/DVE1sy9cOSujK+pPeocdUxiaPUuFO5aU3w3UZJo3bgMaE3SjqmR3i/HYTrWZK+0rntoOBvU2PgOmobL1SjsVzR8f10SW+T9LPg33PM7Nx40eu7flT8jwo+d34P9JRj2e0lzj4jmdlRkv5U0tdjLj+m9jhPPUok6S2SPhF811Z2g8esFqtRBj8XXGTqtZ+TzezM4J+9ym7Y90BPZSy7ne2bpK+qcSfWQ5LulPR3zrnJHuuPqaPsRiz3ZDO7LOH671aQNh3rR5XRx0va2nKiQNlFLJ6U3aJFln0zW9iy3CclfUHSrpBtnB48JvytlseHKbvIVInL71QbFzjOzO4ws1+a2csTbitu+ZWZXaHGzR/bdWBgKTTNOOdFljwsu51lslVU2Bap8VRPcyzqKUp44UjSG+zAq2Knxss6y66kbwevx/iXlkHk0PEy2l7/lWqAObi74BJJf99xJ6AkKbi66DrW+X01CuxH0ghDsI9TJX3JzG5VoxGb6LH8u9R4xcU9kv4iarkowdXT70p6V8jJ8NckXeecuz7Y1wLnXOj7bSIMuz4Qiw9lN84+Y/gvSR/pNTDVFBVn59zHnHPHSDpf0unBd21lzzm32jn3bElPl/SOsCvGHXGZ55z7RMK4AH2VuOy2tW9q3KG0UI32+LmSvmpmh4Wt2C/OHWF5yDnX9k7WXuub2cfUuPvq/Kj1gTT4WHYLEln2nXPPlSQze66kpznnLg1Z/+uSnhasu06NQWjKLjJV1vLb2capUWaOdc6dqMYTAt+Lansj9C2/Tc65V6vxqP5MNe5eVMfvU2nGOS+y4lvZDSmTkTrC9llJhweDwR+QdId6jHmF+ImkseB89ioduBu5s+y+xTn325JeHvy9rU8YaXs9V5oB5uBupEskne+c+2HLT48Eg7DNwdj1Les8W9K5kk5xzm3qs/1j7MDLxd8naa3a70w+OvhOzrmbnHMvd869UNJ1arxjR2Z2RbB+213EzrkJNW7Zb75KY2rb1pgg8LGSusIXNKDzJX3MOXdzx2//qsYrMz7YK1494ttv/aj4r1X71aupdAHCFFB2ewndZ1TZDTFH0gVmdr8aTy98zcxeHxKmqDi3Ol8Rr9dpCu5cvkuNBjeuXmU3tE4DwpS17Ea0b++S9EPXsFzSKjWeLIob51h6rW9m75T0J2p0psMGyKPK6CY1OvmjHd8DoTwru1HbaN6x1PUEQMrilP2XSJoTtO03SHqGmV0rSc65R5xzE8GF5W+o8UhuJ8ouUlPW8hvWxrnG69o2BZ9vV+Np3Gck2FWstrvJObdH0o914BVwkWnWgnNepMK3shtWJkPKbmjYnHOPOufeFQwGv12NfvXKvokQcM5tcgde+XiupOdHLNccX9uuxhwIzTY2zngZba+HSjHAHNwq/01J9zjnvtjx8zxJ7wg+v0ONRkVmdqykH0p6mzvwvuRIwR2Dzw3+zpZ0m6TjrTED5Qw17lqeF2x7anZLNa40nR1s49XB+u+1hqe3hP9kSfeGhPmNkq7pPNkM9nmppO845y7u+O29alzRfXOcOyk7xVz/Ckl/ZI0ZRI9Q40XxV7jGIxSPmtmLg3i9XUGaA50KKru9hO6ztez22ddxzrkx59yYGo/f/Y1z7kety/SKs5kd3/LPU3SgTmhd5mgzmxV8PkKNyY36vv+uxTxJp1pj9t3jJB2vxrtoI+s0oFNZy26P9u1BNSa+lTWeCHimOjrKfeLcV5+yf5KkD0s62TkX9gi+FFFGg/7BL9ToL7TFH+jkYdmN2sa7gvWzvhOpb9l3zn3dOffkoG3/HUnLnHOvCNZ5Usuif6rGRd9OlF2koqzlN6qNM7PZZjYSfH6qGn3S2INUitd2H9IyQDYq6Y8Vfs4dVf4458XQfCu7UWUypO2NCtvhQXsmSe9V46nAnk/1dey/te08WY2n+TuXGTWzI4PP09UYDG+2sX3Hy0Tb6yfnwUyD/f7U6Ow5SYvVeExmoaTXBr89XtLVku6T9HNJjwu+P1fSlpblF7Rs7/tqPLKzX413srwnYr+vVePu5BVq3EXc/P7zahSSpWo8/hC27jRJv1LjfVF3qXG3YnOG24MkXaTG5Fu3SnpqyPpvDcK3sOXvucFv40GYmt9/Ivh+jqRzW7ZxvaQNknYH8Xx1wvXfHYRxuRqv6FDLcncF2/iqJCs6j/Dn51+BZTd0uah9hqz/t8F642q89+3ckGXOk/TGhHG+JCg7i9V4dOio4PupsifpD4PfFwX/P61l2/8RhGsy+P8ZwfcnSzqzZbmPBeVzqVpmvFZEncYff51/JS67Ue3bkyVdqQNt8lsTxvlPg/DslfSIGiefze1eFmP95Wq8J675/dmd6wf/jup3PFWN/sJyNfoPM4vOI/z5+edh2Q0tOyHrRy4n6X41JjHaESxzQsj6oe12r7IvaWHIdsYk3dXy7+8G6y5W44T3SS3bpezyl+pfictvVBv3BklLgu9+Lel1EesPXH7VeGfsbUGa3aXGnEejfdKMc17+Uv3zsOyGlsmQ9aPC9hI12rSlagyCHxGxftS56WeCsr9IjcHeZ7WsszD4/8GSbg/SbImk/5Y0EvwWOl4m2l7v/yw4AAAAAAAAAAAAJFKKV2QAAAAAAAAAAPzDADMAAAAAAAAAYCAMMAMAAAAAAAAABsIAMwAAAAAAAABgIAwwAwAAAAAAAAAGwgAzAAAAIMnMzjCzf+rx++vN7IQY22lbzszONLNXpRVOAAAAwCcMMAMAAADxvF5S3wHmzuWcc59wzv08ozABAAAAhWKAGQAAALVlZh8zs2VmdoOkZwbf/ZWZ3WZmi8zsEjN7jJm9VNLJkj5vZgvN7GnB38/M7HYzu97MnhWx3Hlm9sZg2/eb2WeC3xaY2fPM7AozW2Fm72sJ14eCMCw2s38rIGkAAACAWEaLDgAAAABQBDN7vqRTJT1XjX7xryXdLumHzrlvBMv8u6T3OOe+YmbzJP3UOXdx8NvVkt7nnLvPzF4k6WvOuVeGLNe56wedc881sy9JOk/SyyQdJOkuSWeb2R9JOl7SCyWZpHlm9rvOueuySgsAAABgUAwwAwAAoK5eLulS59wuSQoGhiXpt4KB5cMlHSLpis4VzewQSS+VdFHLAPLMmPtt7udOSYc457ZL2m5me83scEl/FPzdESx3iBoDzgwwAwAAwDsMMAMAAADtzpP0eufcIjN7p6RXhCwzTdJW59xzB9j+3uD/ky2fm/8eVeOu5c845/5ngG0DAAAAueIdzAAAAKir6yS93sxmmdmhkl4XfH+opHVmNl3SW1qW3x78Jufco5JWmdmfS5I1PKdzuQFdIendwV3SMrOjzOwJQ2wPAAAAyAwDzAAAAKgl59yvJf1A0iJJl0u6LfjpXyTdIulXku5tWeUCSR8yszvM7GlqDD6/x8wWSVoi6ZSI5ZKG60pJ35N0k5ndKeliDTdgDQAAAGTGnHNFhwEAAAAAAAAAUELcwQwAAAAAAAAAGAgDzAAAAAAAAACAgTDADAAAAAAAAAAYCAPMAAAAAAAAAICBMMAMAAAAAAAAABgIA8wAAAAAAAAAgIEwwAwAAAAAAAAAGAgDzAAAAAAAAACAgfz/5MFlrrS6LvgAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1800x216 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data2[\"target\"].plot(figsize=(25, 3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "ae2f385f-838f-4e37-815f-ee0b6bbaa4b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='datetime'>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABZUAAADQCAYAAAB/YI/SAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAABdEUlEQVR4nO3dd5gkV30v/O9vZjavpFVYAZIQC0LA1YsxYZEJxmCDQeSkew02mGi92A8GRywuNsiAScLCAhlkIUBgCwQogFDOYSWx0uactDlpZzbO7k7uc//o6pnqnqruCqfqhPp+nmeene3pqjp1cp06dUqUUiAiIiIiIiIiIiIiSqLLdACIiIiIiIiIiIiIyB0cVCYiIiIiIiIiIiKixDioTERERERERERERESJcVCZiIiIiIiIiIiIiBLjoDIRERERERERERERJcZBZSIiIiIiIiIiIiJKrKfMg5122mlq3rx5ZR6SiIiIiIiIiIiIiFJavHhxn1JqbtTfSh1UnjdvHhYtWlTmIYmIiIiIiIiIiIgoJRHZFvc3Ln9BRERERERERERERIlxUJmIiIiIiIiIiIiIEus4qCwiPxSRfSKyKvTZpSKyTkRWiMhNIjKn0FASERERERERERERkRWSzFS+BsAFLZ/dDeCFSqkXAdgA4LOaw0VEREREREREREREFuo4qKyUegjAgZbP7lJKjQb//S2AswoIW2X9cMEWvOXyh7Fm9xG8/N/ugVJq/G8/WLAFew4PTNrm18t2YdWuwx33/YVfr8K8i2/FxTes0BrmNJZuP4h5F9+KA8eG8bPHt2PexbcmCjsA3LPmKSzcvD93GG5cshPzLr4VCzfvxy8W7Ui83cLN+3H3mqdyHz9perlg2Y5D+D9XPoZdhybnSxfds+Yp/FZDHsuqVlP4z/s34fDxkcKPNTA8hld85V787c+X4fBA5+P9YtEObHiqv/BwtaOUwsU3rMAXf7MGX719LY4MTg73r5ZGl68fLtiCeRffip89vr2MoAIAHli/Dws29nX83rfu3oB//tXKEkJkh8GRMbzjigW4beWeTNtHtQV/94tl+PyvV8Vs0ezwwAie/8+3Y9v+Yx2/e/k9G/F/byombWo1hYt+sgg/Xag/T27a14/5X74bo2O13Pu67K71+ELCuE3rwLFhfO+BJ5v6OtRMKYUX/Mvt+KtrF5sOSmJrdh/BjUt2mg4GhSilcOWDT6Lv6FCi7z+wfh8e3tgLoF5nX37PRgyNjrXdZtWuw/jV0l25wrml7xiuXVh/H9Dew4N467cfxrq9R/Dwxl48tKE3177bWb+3H//14JOF7b+dRVsP4A2XPYiRDPX1ku0HcXvQlvb2D+G/HkxXn96/bh8efbJzPwWo56HXXno/Fm87GPm3qx/ejC/dsgbzLr4VOw4cTxyGKLsPDeAHC7a0/c6jT/bhn65fERmeIo2O1fDNO9fjq7etxSU3r8ZXb1+bOM53HRrAC79wZ8eyFHZ0aBTfuGMdjgyO4LK71uMv/6feFly/eCfW7T2S6Rx8sHLnYbz7u49g3sW34pYVuwEAn7tpJeZdfCsAoO/oEL56+1ocHRrFql2HcdPSnTh4bBjffWBTbHrdvHw3/vbnyyLHW+I06sfh0RpGxmr49r0bMThST9+l2w/i1hX18nntwm3Y2te535nXrkMDeMcVC4zkjUY9cM+ap3Dpnetww2L7+gE/WLAFn75uqelgeKVHwz4+CuDncX8UkYsAXAQAZ599tobD+e+Lt6wBALzl2w8DAG5augvveelZ2HnwOL50yxrcuGQnbv3Ua5q2+fR1ywAAW7/21tj9Hj4+gh8/Vu+kXffEDnztvS8qIPSdvfu7jwIAXvqlu8c/e9t3FrQNe8PHf7IIQPvzTOLvfrEcAPAnV/0WAPB/5j8z0XaN7+c9fpL0csW7/vMRAMCf/2Ah7v3715kNjAa68lhWD2/qw6V3rse6vf34zvtfUuixvnPfRuw9MoibggvAb/3Ji9t+/zPX129Gmcy3G/cdxXVPTNwIOnPODPz5K+c1fedvfr4MwORwNurWz964Eu8/v5z26MM/eiIyLK0uv3cjAODL7/qdwsNkg5uX7caKnYfxV9cuyZSfosrpjUvq+fiL73xhx+0vuXk1hkZreO2lD3Q8/rfu2QAA+Mq79afNw5v6cNeap3DXmqfwp7+nN0++4bKHAABXL9iCT7z2nFz7+vZ9mwAA/5ogbtP6x18ux73r9uHl807G/HmnaN+/D1bvPoLBkRpuW7kXh44PY87MqaaD1FGjD/uel3LeiS2W7zyMr92+Do8+uR8/+ej5Hb8fbr9+sGALvnXPBsyc2o2/+IPnxG7ztu8sAAC86yVnZg7nu7/7CA4dH8H7X342/v//WYzVu4/ggv94ePzvRfVBPn3dUqzb24+P/f6z0dNd7muHLrzyMQD167MPvuJZqbZ9T3BdtfVrb8Xf/nwZFmzqw6ufexpeeOZJibb/yDXJ+ikA8Njm/di2/zje+71HJ31/6/7j+PKta8f//5pv3J8rrT56zRNYt7cfb37h03HGnBmR3/nT7y8EAPx80Y5S+6a3rNiDK+7f1PTZG897Ol72rJM7bvvqr90HAPiHX65I3M+/YfFOfPeBJ3HSjCnj7XF9H/XrWR+uJ7N4+xULxn//5E+X4m0vOgPXBjfpjwyO4EePbMF/PbgZ55w2G58JJtRd8P89HXes3ouXPPNkvPKcUyft81M/qw82rtvbj9s//ZpJf49y1UOb8a17NmDWtG5M6+nCZXdvwMhYDX//xuePj3tc8MK34HM3rcLJM6dg6effmOu8O/nQDx/Hpn1HccF/PFx63niy92hTPQAA732ZXf2ALwXXg5e/r9jr7CrJ1WKKyOcAjAK4Nu47SqmrlFLzlVLz586dm+dwlTU4Ur9rPVar31HrHxxt9/VYNc4CogIdyZgvqdnIaL28Hx8qPj4bdQsAHCvheDqMjjXXYwPDyWd6kD2OGs5vTx0ZNHr8hkZ5L1Jjtoyt+oO8MDLGPkqc8OxFduUoq8ZTC1na+0Y9cryENvdQ6Emt/gRPUemybm/9SayawTI2lLO+brStwxqeUInS2gcL032d2bjeHTOZIDGiZhmnDefRiCftYr8bpOuhEsuD65QCjgzU420gVK4acTlaa19G+lOkT2P/Q6O18WuruLoyyZOheZVxjDijFpZXKl7mmcoi8mEAbwPwesVnFgvFwWAiKkKXmA4BVZUYznu2tKum48EGjXpIwY40IaLJuoLKqoy6U6Q+IGSqRnC5LmrUp7WCBnbatVm6m7PGsSxprrVLc1pllj+fTOSh8uLN93xLFCXToLKIXADgMwBeq5TKt2ASdcQ6iVzAsRG9yij3HNAiU7oMZz529u0hQevBNCGyV6POLmNwRmDm2md8MNvhuqi7qzH4WMz+27Xdutt18fyGY5p8VvTNAh+JhOotw2Eh8l3H5S9E5GcAHgPwfBHZKSIfA3AFgBMA3C0iy0TkyoLDWWmcCE5UHWWOtZke2KPqMp31bGlVy4gHsfyWH2f1EJUry3VFY1BrrMSCWvb1T6OmdLkukoJntLZrTbQPKnt+wzHbTOViwuI7E3nI15shRFE6zlRWSr0/4uMfFBAWiuFrY0pEZonpkT0iQ3iz1h6+z0Yj8kFXwTNgwySYMszlL9Ibn9FaVBvXbvkLzV3KibbBT2n6IVJ0unoonB3LjDURv2+GdFLV8666cl9tS5nw4pdcwPFJ94TXVGb6UZlM39DgbB97+D4bjcg2WerfUtdUDv4tu07o8mAwaDydCnoHbLsnX7QPKgf/8jp4YlkTRkU6ZS3bIzG/E1UFB5Ud0Hrx6/IddCKyB5e/IFNM57wqXaTaXsx9n42mA+OGTBt/oWbZmbHE+suG2aB5b7hOrKlczDm0e8Gz/jWV3VoPN22/It2ayvW4GOMd8cREpLTltZgqVHUcVHZAo2Ng+7qIROQW2webyF+m854tFwBltOss5kQUlm1N5fIHtcqeRDP+1ESpR22W94ZnYyC2qLWv2w16F/aiPlsabM3S5O+ugm8W+KpdjjQVlUxB8hEHlR2gq9JjJUZF4k0P95hegiALB4NMEUzXF9ZM9mF+Hlel2eN5sA6krPLknTIHtYwNJnowiDkxo7yoQeVsf8t0rOBfX9uGNKfViAtr+i4OEES/syFpPs2anyWmDJbZdLObQGXjoLIDuNwFERWh3WOMREUyPTDm60Wqi1x7xJmoispc/sLUTUcfBjGLXlO5Hf0v6rO3bdCRR9PcoClrbWDfNPJQmYPxvLSiKuKgsgN2HhzA0OiY6WAQtXV8eNR0ELTbvv84am16IsOjNew8eLyQY5dR5l1cU7ms/vTgyBh2Hxoo52AVpCvnHR2aXO8cGRzpuJ0t12VllEDbi7kPAznkhuPDo9h3ZNB0MJrUagrb9xfTjwjbfWgAQyP1kcbRDCMsjf5C79GhVNsdHRrFvv7scT44XN71jw3LLeRdXqSroOUvDg+M4MCx4bZtlvblL4J/bWwa9h8bzr2PNOfV3aXvuFntOzJo5FpvdKyGHQea68itfccSbdvIQ8OjE3dZ8uSnYx3qs3D5PXg8ui9aRn4u8hA2tqNkHgeVHfCTx7bh736xXPt+OWBCOh0Z9GtQeUvfMfzBpffj8ns3xn7nn3+1Er//9fvRn2AQK6lGZ+ORTfu17bPTsQDzyxEkNX1KOc3WJ3+6BK/62n2lHCtsZMzA9CIDdF18vvnyhyZ99oqv3Ntxuynd6Y9/sICLORsvlsvWuNjbcYB9Eh8dHtDXPub1nu8+ivMT1A9luvzejfiDS+/HloSDJFnUagqv+tp9+NR1ywAAh2IGO9pp3PS5dcWeRN9vlOs3feshnP9vKeM8NLi7+3B5gxddFsyM/ert63JtPzhSH4Q/FnHDNY/f/de78NIv3Y3pU7pjv6O7Fxm1dIEtvn7H5HR6cENvqn2kOaupPfW+791rnhr/rJHWZTn/K/fiPd99tNRjAsCld67Ha75x//i4xa0r9uB133wA9617qsOWwHDQp77s7g3jn+XJT2+/YkFkffZUMMh62d0bxmdH37x8d+bj5NXbn+7mXxoXfu8x69pRMo+Dyo64b+2+3Ptobez3HzV3t5PIdnsO1zsvC7fED+7ev77egRzQOJOmzJdwzJk5pbRj6TJrWk8px7lHQ52bRWXe7K3p6jNqIPJ4gvLY7sI4Tn8BN856Mgxup2X72unPOnUmgHLigsqne3Arj3V7+00HYZLHNtf7GHsLHDxttCp9wSzjk2akb/un9qSrMxtt2S6HJrBMrFvrbjt84ox6H6kxCKlbWX0wIPTiREeSY33a+iXFec2eNrnMZnniIC8TdegjT/YBmBi3WLX7MABg7Z72YRFpnqHckCc/be6NvvnXV6ExlTV7jpgOAlmIg8pERBZxpO9MlIvp4UNbLlJdeUKgSBMvADMcECIDxh/xL7H1t3Hmpw3G1/B1OHp8OIcGG5YjSSNtMNOUQ74DRR+Xbxq5gNFbTRxUdhALK5G/WL6pCmyfPVsWRkPoBgMrv1iMGn/JxKgyGWZigL8o7p/BBB/SI0qaG6kuvgPFVkW0p+F3QtiQVLwJQWXjoLIjiqigfG2kicrGklSesgdX+PKwYrC/Sw0T62YSVc/4I/6Gw0FoWsvZVePrQhs4Cd1H7PJo1nVeUeMA7J92Fhlv5Qej9ONy4gaVjYPKDmI9QVQCY301MwdmvRKNffZiML/VMRrcWzfThHB54ZIpfjHxiD/LWrTxmcoOx48P59Dg2vIXaaUZFOYgYTZRUVz0YLwNKWVDGKhaOKhcIa1VKC9MiPRgSSJKh49yBkqIBtujemLgwNORg4qzPf+ZNjFTv7j872oSlP1EZWN9d5ef5CwjP5XFtXNJ24al+barZVinRj7IGxeFdzUsaPQsCAJVDAeViYiiGGqQOa5iFyZHMUx3eF25SNXB9hvI4484Gw4HkQkmZupnOVbaOjtPHW+qxmoc1+WXhhY9U7nMm3++P8WS5ryivlqV2ctZ+zBK2bX8RZmqkjfIHhxUrrAqXVQTFUlnSWKpJKqOMgZ8dV5bFDmg4PJATpnYdyPfmc7hLj81IR6tQ+z7evt585nL+dSkWgXijS/qo7J1HFQWkR+KyD4RWRX67BQRuVtENgb/nlxsMIl1A5F9iiiXZfZ1XLyRrWtAJWlnnJ32YpieRWFLsrpWBouIN5MvliIyzcTAGUtaNB9eDDc+U9loKPSYmHXtxtmkDaUbZ+W26DWVyw9H2Wx/Qo38k2Sm8jUALmj57GIA9yqlzgVwb/B/IqJKKaJfwlloVAXs7tYxHvx/GVPVMV3ba9xgq8LsOdv5UBeJTzfpuDQSFaAKL+rjTGUqW8dBZaXUQwAOtHz8TgA/Dn7/MYB36Q0WtaOrLuRdLKI2UpQznSXJ1HWAazMmy8KLmWKYzm9M12yKiLeJmXVMlTg+jA9RtPGqkGlsAY9e1OfuKYzrcuxc0oYz1ZrKrkRCibLGSRVi0vTTgFQ9WddUfppSak/w+14AT9MUHopxbHhM+0X44OjYpM+ueWQL3vWfj+g9kAPW7jmS6vuuN+6jYzX8/tfvwx2r9nT+MsXq7R8CAGzpO6Ztn27nLHf0Hh1K9L2xAhd6HaspvPbS+/Gb5bvHPzsyOFLY8WzS5WCHd1//YKH7HxmrFbJfnTHdl7DcpDEalLGv3LYOw6PFxAGZc3jAvjpttKCylkWjhRmK6JMXJW2fN4sjOdK9UQ/sO6K/vmmvnhqvvfQBrNldfByldfXDm3Hh9x6N/fvgyJhX04Ual1oDw+WVjTwee3J/qu+v3HU41/FMXy8Mj9bw6q/dh7vXPFXqcfsHRwEAi7cdnPS3dXuPhH7vx5TuyUNdjXyl9X04oZ3FdW/b1fEfuHohrrhvo7bwnDC9R9u+4sS1ozpuyl1y82r8zXVLc++nE5v6Aq7L/aI+VR9di809InKRiCwSkUW9vb15D1cpp82epnV/rXXc6NjkZLvkN2uwbMchrcd1wY8f3Wo6CKU6eHwEOw8O4J9/tarzl6sqRc/8xiW7tB223DdrV9cD65O1R4MjxV3MDIyMYdv+47j4hhXjny3fke8iwxUnz5xq9PhZ8v596/ZpD0e4tB8bGtW+f0DvrPAHN+jvx4UH64sYtPaNa0+ZLYq48DfNpoHuRhvj4o22dpZsP5R7H49tTjdIl9eMqd3jv3/ltrWlHjuJL9+6tm152rr/WGiNbtNDjvk1bi505R6tKMdwxQao9vUPYtehAVxy8+pSjte4PFqyvV4G7o/ox//40W3jv//3Y1vx/KefMHk/CcuG7rb24PH4dmfBpj58864N2o71x+cVP9/zUIHt6DWPbsWvlu3u/MWcjg25ccPKBVmr6adE5BkAEPwbe6WllLpKKTVfKTV/7ty5GQ9XTbOndXf+EhEZx7UQ/TN7WvF3+avMxfGTIpd+qDLfBtOI0jhx+hQA5mcddpK+lOY/o7L7VqfM0juZx4TGQFiBD1mV5sQZQT/Mg3MpQlVaznRdhInMEte3KKJaSTJQXSuxUE6NmKGtmw+XvmM+nIQlsua4mwF8KPj9QwB+rSc4VCQWG6JisGyVh+0/mcKbR8VcxPbwjTJUYT6tgRum43zKjhPXqyKBeJWfXHsqg8qRdJC5K6ZAF1E2kuRV3/qQPjwN4VuamNRxUFlEfgbgMQDPF5GdIvIxAF8D8McishHAG4L/ExH5I0U7o7NRMvaiPnbeI5WdHq6v156U6dPMcvhCLkRCV0em4ySJIoIYd+FHVAWhGsBgKPTTMSmv7PbQ9ZpIZKJN8WHAhyZEpWZVUzjp9Upc16LogcS48BX5jhYjYk7HpevJMmeP+67j871KqffH/On1msNCZEyWN/b68MSuC4MYpiW6+6yxUSr1QsCHTOwZFkl7uTrgb3sHv5v1EJXMppLs08zSMB19mbKjRDyoi4rOTyayqWdFwzul3/xJWExN9X3iwlfm+GUZVVnc6bh0Q4tjyvo4svQ9EenkQb+5NInWyWKj5B6mWbVlSH9Xy7nt9X03ZypThXWNzyz1i4vLX4RrItvrzU58yE+up4HvbL8J09UVXYcUMVM52bWiD6Vygg+n41uamMRBZQcx/xPZRWeRZPmujqjZHXZ30Yn04/IXSTjcMLBRa6sxLsOL28nKjhPLx8g6EoQe+fcoP3l0KpRDkmwQzitxg96FvKgvwT7LrM/KGPB3aUZyHO+WJDGIg8pERFFStMc6H/1i57k9H6PH9tkeVFd02fQxbycRXv6iqnFA1dV4RNv2tj9tM6XjdMq+3vehLW7kJxNjJbrzsAfJQRq0ZoOk2aLTmsqdrt3SDJq221UjH/s2gGl7m5WED+dgCw4qExHlxBlG/io7ZauSk0zPcMhy/CLKuXMXzQUkGycq+60qdVpW42vgmg2GdjputvNFfek516YkYLq/YAVGQWpdcTOVCzhW+FCt1Vbjxrl3g8qmA6DBGK/fteGgsoN87DAQWSdFO6Ozo2CseWO90qTM6HD1BXBEVBaJ/JWysanKbcyO9a0dcHFNZdeJTFQPPuQn218yS3Wl57SEAyFxg8qNAHd6MiFN/msaVG6JkUY4PBtTjn1JvUtVDyeF6cNBZSKkvwvuehU03uk0Ggo3JOlU6GyTfLgQcEGnMl9GKvjwqG2VsGwWg+WAqszX3K/jYr3sGaqxg1DOkPH61KcBLDa9diqrtLQmf/LlLySyDikiO1Vx+QsfxA2MU3ocVLZY0RdafJwou8bgwlhN4ZpHtmBodMxwiPxz1+q9eLL3qOlgJKKzTTLWeWZ1YAXXL2lttv/oEH7xxI7M2x8eGNEYmsmKGrTW2ZcYHqtp21eD8+M41NbAMPtHSRRdv5RtcCR/XVF2fyhcF7l+s+vyezdi/9Eh08HIxYYkWLCxD6t2HTYdjEgjo/rbY5sJgC19x7Bsx6HY74TrjLiltUYK6MfEhaEejnpAhkb8agtHNV387jhwHLes2K1lX2l9/+HNRo7rIw4qW4yzouy1eNtBAMANS3bikt+swX/e/6ThEPnnov9ejNf/+4PGjn90aBRA+5svp8yaCgB4w/86Xdtxzzl9trZ9dRLub92z9qnSjuuSsuth1vrF+eRPl+IzN6zA1r5jmbb/1TL9nd6ZU7u177NIRVyMPfPkmdr3Sfb4+h3rTAfBao0Bq8//erXhkOj17Xs35t5H2ZPIwjOVLRjPzOTUoF96eGAEf3XtEsOh0cNkv+gDP1iIt31ngcEQxPv+w1tMB6F0b7is/XXh6j0TNwDibkoMFjC4G75UUE2fq/GJZ2XWZ2X0LX+5KPskjbC3X7EAn/zpUi37SusXi3YaOa6POKjsIF1jHFyrKruBoEE6OlgfeDzi2QwTStb4n/eMEwEAZ548Q9txZ0/r0bavNIYcmfGga5C3027KqB2jzqUy9xKD8yzzJW19waytImbbZtVdQgToPEIRj4fPcGxg3Qx3KwY+XdpeEQMcNjg0MJx7H2U/UWnDzNg8RIBZoT5kn+MzlWlCVFnoH6zWtadC5yUkwk9IxD1tUPYyNyfOmAKg3Pqlp4S+ZWPyVau053noeLXysa84qEyUQWUGfiqNiUzlcP0x2zzKPPfGhcRYTVWqDq9w9iKKZNPyb67U/2knovBFfeUTFF/fm0gTPrlrt6KTJ2uWVqq8vl67NqU71PesAhbXauKgcoXZ1Kk2LW0F6HrD4OvbxnVqJDFn9FcTS4Z/uroaLzCyM3WLCpXOGqzoNoNtEpEfdJTksl+i5MoAf1UwPdoz3Vranjxx3YnC4y10YKUQenmm6RTTS/fpsP/nNg4qW4xFy16+NQw0WRXS2PYOYV46Oijl5wL/850pjacBK1C0C1P2W9OJyFE6Zirn30UqnneJnMUmgpJK0+8vahCzda+Nvqdv15W6Jyc6Pl+v8jiobDHP6h6vjM9iZQ/UW6bKH58g0KfdEwWdyi6LdrFM5PKu0GwRljIiouLoqGXL7oeF+wUu9u99m9nr19nkE1UWGD/ZJI23rMWpNa0a786o2fM6Dyv5NuheNRxUtljRl718rD87PqLhPzX+L9PaJmmKXru73izC1TMxW8RsOMKYD4nIRzrqtrIHGSTmd1e4GGaiooiUN4Gh3VIb4+/zKLE+K+NQuo/BQWW3cVDZYkWXLQ6WZWfToAQVo2o3Djyb4AKgfQfFptStWl4LKzPbieUvSykqG+icvVbhrEo+sSgf+9j2AnoGCEpf/sKDxPCyjvbxnDSwJVrKGk9I21c2taZyazhFoj93na6z4dJ0fuCgssVYuMqTNqrLvNtYhEa32e2zKFaaJHY1O4SfVnD/UmoyLRe1jqYtTdZ4BNG3jn2ZGHNEejkzjpkynDrqirLr6i5X0qIinCkbFVXaE88pMoINfZTJayo3JjSUHxYXdHn6IsOqyTWoLCJ/KyKrRWSViPxMRKbrChjpxwtpfVrjknHrn0bjVpVlYnyYodPK0gmpk4TjnlVJcWxc/sI1Rbd1PtZDOrBe8JevfQwdebb8fO92WvhaffLJWnKVUmpiTWXPGnJdpzMxqKxnf2RG5kFlETkTwKcAzFdKvRBAN4D36QoYxT8+QeZNDDiSr9I0liybdmq3zIFnfTvnmIh/Cb+or0IZgPUTEbmo7MHE5hf1uVdx+naDwq+zyYcv6rNbOHla00rGJzT41u/Ucz7+xk+15F3+ogfADBHpATATwO78QaIG15dY8FnrIyxMK/+kSVEf7q662jltd93XbuBwZKyGI4MjBYQoHw+yUiplXrd3hTquNsaznaEqV5UG+4kA3vRpp+y+lesv6hut+fl8/eEB+/pqNmBrOdlIywX68OjkMlF0P6N1cLTb8vd5ZKV7prLys/qqjMyDykqpXQC+CWA7gD0ADiul7tIVMAKeOjLU9H9ea9lj58HjAID+wVEAwP/8dnum/SzbcUhXkEizO1btAQAs3LI/9ju9/fUyevk9G7Qd11Q5H03R2ek7OtT5SyVpF1+DI/E9lC/cvBovuiS+yeofqpftm5buzBy2LK588MlSj2damfl9IMgPx4fGyjtoB+Hz/9XSXYUcQ+fgyEkzpmjcWx0H09PhIGR+NuW4Z506CwBwyqyphkPSQSjS1u/t7/j15z1tdu5DNvpYrY4F7bNu06d0F7Lfsnzm+hUl5O12L0Au5uh/+/PlhezXdT9dmO3aUzebxid2HBgY/10B+NItayZ9p+/osPbjnnt6dH2nMFFiyrx2CifJ8eFi6ssH1vdq2c/ASL1PPsxFp52WZ/mLkwG8E8CzAZwBYJaIfCDiexeJyCIRWdTbqyfzVcXcE6Zp3Z+Lj3KVJW2DOK2n3vHMO9Nx/d4jubbPauJNtEYO74THtxwA0H6mTG/QQViy/VAJISrWzKnJL6YOHNPfIStC62yBZ5yUftn/R5+Mv6lQhBU7D5d6vCqZPa2ex6f0dFk5C+2xgvKazrb/aSfy1RkmhJOwm305r7z07DkAgPef/0yzAUlhS9/Rjt9570vPyn2cuJtYjUEI3awf2O9g0baDpoNAFcKmaMJrnzc39m/TeurDbSdM139TPomB4WLqS11Pe06fknfhBLJBnlR8A4AtSqlepdQIgBsBvKr1S0qpq5RS85VS8+fOjS9wNBkH/IjMSTIQ49Oj2j4OVLSmTpYz9CiJK6/LwzxeNhYHomJ0d/l1Ya2juo1rf9kuVwMnQ1GYzcU+nFdbJ7R0hd7nQZNN7far7auqPKm4HcArRGSm1EvS6wGs1RMsAvwasPJN4xGvvB0eJjG5yJV8W9OwflmRp+pINBbC5JIHyto1le3HfglRQWwvWwbG9+IGYVgPUdVUOce7cGshLoxKhd7nwTWV2++v0rncfXnWVF4I4HoASwCsDPZ1laZwEXhHi8ikKkyQ8OEciz4HXrwWq8w8yFlP+bE0EOklTgyZtDIb5jLqITYX5jEJyEWtY8ddXRL5uet0DQKzb+6HnjwbK6W+AOALmsJCLXyrfIh841VD6MiptI7xthvznfTdDMcr8uaeI1FORIbx3pZejE+3lTPpxs0WOnwj3Ks+KlmL1WmzuOUvxkoc2DHZxrF9rSYuYmKx1hlyefsGnHEXL+3dNtejsjEzhnkiXpL1Vxl/dtNx4ckk9o9NSerc434FB5fljYga2MeqNo6J243JEy1cbSmoieUvPKvPPDsdyomDyhYrvKyyMsiNDaq/kqRtEUWIjbQ+OqKS6eGPqtbXOi/MnRsEJ3KESyUrSZ1SZNvJdpmIOimznmhXJ4qnL+qLO5vMfU6/oqdyOKhsMc/qHrsZimsmsdtcH6SSmN87cWVgSccsJ986gbYwHa2mjx+lqDDpXLO1iDDamBZEPtFdxMq66R63D7bLVeF6L1sfztrXr6gYbU2rbvFzTWWiMA4qW6zwThPbaqJYSe60+rRenavn0i7YOjpwRdbC7F+ae0kV4z4bXtcSFcP2FthE+OKug8qohxztEhFRIG8ZTrN5+Fjhaw+lgK6uxueedaA8Ox3Kh4PKFvOu8qFJ2GclF9n0tvr21aTlo8pkBtM0M0Yd+cDGp21sC1G7mZGmb0KXMqhc/CGcZMuSAmQPW4crTIWr9biNd/TUPJuqHNeOZo13v2KnejiobLHCK0OW3nFpo0LXY0jGkkAMH98BSS6aqvo4mskL8jTH1pE8ZZwrr5vKEVekbSnHRYWCF+ZE9mL5jGeyama6EHVgeRkxda3SelwxsPyFjTdO47Cu9QMHlS02NFpLvc2BY8MFhIRi5awIdx8a0BOOkgyP1nDh9x7Foq0HTAelcIcHRjp+x50mO5rvDfmGp47m3odnEwusYVO09g+NGjt2eNBk6faDhRxDZzG/a/VejXujLLL0DYnyCtfZ/YOd+0c63Lt2X+TnX79jXSHHs+UGIyVzfNhc21025kx3tD7N2RX894r7NxkITXHKqC6PGuyfUzocVHZQu07PbSv3xP7N9ONqNkvbkdRVkf7ksW16dlSSrfuPYdG2g/jsjStNB6VwrzrnVADAa849LfY7A8NjZQWncD5WD/9+9/rc++BFpn9aZ3As2NhnKCTN+geL6TzrLNu/XLxT384osXCOPVpQPiGzbGtqWsMzHLqZ8cD63tTbZ7H3yGDk57e2udYhf3Rqup7YWsyNWKK0wvXdc+bOavpbT7Co8rChG8JFjf/obrKi2oyFm/drPgoVhYPKDkn0OH6qHWYOCgVsWluW9Gq8rff0E6aXelyXHlmyQdtq0ZGodCSYxSixCo07lG2DOUStmEf95WIv0seb0ERkt7TtIF8E7YZ2qcSnRd3BQWXftKlxJ824Y0E1jh1ze/FFmW5ol0ytf8qSpEXmAhb/csWlJcs6uYQ3HvNjkSdf+ZS3eY3kCjsznbE1lUOF0Kfy2KqMJznZP3cHB5UdkqTw8o5ONqlf1FdIKAzw5kT0S1KW2OEtX5r+he2dEbtDVx1MB7MY/1RlruT/qvV3+CRiBq5kZnJKYXVPh/zqcnYOX/4UNfirffmLiD1yCUJ3cFDZMyx85dAVza52WauQy2wfkNQtTV50JWpcCWcVmWirmvJ400wSZhQiorAq1opVPGebcWB/Arsp7qhKWukqne2Wd+VkSXdwUNlBfOGeP4zXlSmzUhVyXqN4NQaV2z0+5VOH13heLICOGwNldA79yUXuCCdrVS4AyF3hbh/za342daMtCgqRU1h2bOFoShQU7PB1o8/LVZUxHlW1CV4u46CyZ1j0yuFzI1F1XUEjWTPzkl7SaPIy8iy3tjFxKVK1fOHTzS8iIopXdHtWZmtp080foqQmj4P62ceMe8pPZx3Emcru4KCyZ1j4ypW3w8P+kn26WmYq+4yDTVQlcbMqKlDUiSjExjLv0s0t9hyobFymymZ2po2pLFOVrKrrNBvtSVS8sdy7g4PKDmpXwFj4sskabXk71qaWMhk/bMbz9jmfNdLE1KAyO0H6aFn+QkM4yG7e34zlCJDzml66Yy4YVABbZ2P63M9LwtZ0qZIqpIHL5az8iSnlxlWapAl/N3zt4XDyWqEKE7x8kWtQWUTmiMj1IrJORNaKyCt1BYwm41rKxUlbZVW1jqtCFuweH1Q2HBCLmcz/aQ6tJZxVLewFMxmrSpXzZmxbVKDa9p7veZTsFx5A8vV6JFzMfDhFD06BxlW3DXAtH9uQUuEwFFVfl9Et4VKU7ujJuf3lAO5QSl0oIlMBzNQQJsqBd3TKoVr+JX+kWf7Ch4uOBlcHLdqlgY7Hid2MFXeUWYbiDsU0Jpe4WldTtbi0nAfZiUu0kZMsq/ps7zM0rgOiQslxLXdknqksIicB+AMAPwAApdSwUuqQpnBRAVgs9dl1cMB0EKiDrX3HsHDz/tTbNV7Ut3T7ofoHbQqO893djCcwPGbPreN2/Y3W2ebsmxAAHDg+3PR/kx1u5kkwEiroN8t349jQqLHjM8eRr1iduqWI9HpkUx92HDiuf8cxnM1zBYU7fENNwXz8HB8eK/V4Os+37LBTdnmWv3g2gF4APxKRpSJytYjMav2SiFwkIotEZFFvb2+Ow1ESpiuuqrhhyU4t+/nD55+uZT9lcyGbve6bD+BPrvpt6u16uu0ZKt7wVL/pIET64m9Wmw5CIm9+4dNNB4Es0h8MYn3m+hVNnz/zFL8fsjrr5Pzn191lT71Iblux8xD++mdL8S+/WmU6KNRGaz+PM4/d43yKhZodXt8m92dXL8QffvMB08GorJNnTjUdhCavv+xB00Foq13ZHhzhoLIr8gwq9wB4KYDvKaVeAuAYgItbv6SUukopNV8pNX/u3Lk5Dkd58ZLQPuc+bbaR42bPC/7nou4ue95fOlDiHdo0/fXeo0OFhUOnl5w9J/c+eCHjj7GYhdJPnTWt5JCUa87MKbn3MXta3tXSSBfXq6Sjwc2d3Yf5xFeYS22N/z1BIreNlvBiGJ+WANRp+pTuyM//+LynlRySuuHRcp8uzZovop4a7Om255qc2suTUjsB7FRKLQz+fz3qg8xkUKqXWBUWCvdkffw5b3tq+iIi/eH9zzVpGkOvYsORk7F9bTBKyEAyhos2Z92lw4nKRMXw9aV3Lgq3C1zP17xOKeBD0UnaE2HX1504CAczfM1SavhdiSz4UY4px6CyUmovgB0i8vzgo9cDWKMlVNSWO9WEOxin6fhc/6cZPCk6HopuaH1Ix7Yv6mPBtl6ZF+7suGbXxcgzyseqjPWz3dqmTxWqgyqcIxHFSjP5INk32eiRv/I+z/jXAK4VkakANgP4SP4gUVnYXzLP1et0n5tFm2an2BSWMJsGA9KEJUuwOaPVH3HliWncWVmzKW2qW2wSjhfX48iGds3GJ17sC1GztOlmYRRXQtHRbipdmZ3sVXTauPY0R2v7osY/Lz8sJmQ9z6rEj69yDSorpZYBmK8nKNSJW1UqJeFeBep/LkzTdyl69l6Z/SjnsmICOspXkWXUvfLvOP+rr8I4dk1HRESOc20wMYv6AKT/51klKsHvFBaf/228AUzRuPp1hbGYmmdqhlwVOmpZtcZMVcpJmoab2UczxmcpbIzmMtoAHeWVayqTblVpW4mIfFRWtyDrwKKxAcmYw1ZlgLQaZ0mtOKjsmYrUV/qZandMv6jPdAAsVKUB96zn6kq20RFMV87VNSZuqIWfLGC6psM1lW3iduZlVopmW7SE6+jWvqINS5gUge2CXfzMZc0Sv6iv0FC4oey2I/MyDjGpxTQkn3FQ2SGsjIrDNTVT8ji6qnTBG75QTDPAbPLCq/XQXqSXx+WpkzLTL+5YHEjorMhBZUY/EcuBbXzoWpStyDzMSTDkIlPvQ3CptHhxHUccVHZR1rI3aTAmb0Aod0XoWkXqWnizaD3HCpwyAHc77O2CPellGZadYhXKE/mBedUsL+Pf5M1Jy9oC27XGl5f5sYWrT635lLcdTYLKKev6Ie1hTJXh1nA24qfmU+EkasFB5Qpj1ZZf3kcA2b64rYjkY56wC5PDH+HrC5azdHhxb5ap2U5FYFZyE+sAIv1cr8/LkH2pPkau65iE7ugxHQBKj+WLTBtjLV+Koi/iXJ2JQ+4zXYU0vZGb1VlHvq6h6gou0eU/2+qhphsZmba37IQScC/EfuvU6lSpXbKxOBV5DTEyVkOXCMZqytgM3zSHDdd3zTeBJ/5z4NiwjmB5p5GLbMzjlBwHlR2SpOrmhUc2Va3Isp72tv3HtYbDZlXJGsNjtcTf3XVooMCQ6KPnRX3F5YCq1ju2+cad63DNR843cuwy8sCy7YfwgqefmGsfZd1/Yh+mM9diaGpP9EORTOs6V+7thusqR4JMHmFtUS3nfu52vPq5p+KRTftNByW1lbsOj//+9TvWj/++evcRE8FxGvsJ7uDyFxXCTmA83W949RXzULOi46PMWRhjNTfyspdrO/pwDhmZOvXwcR9Y32soFOVYvO2gtn29fN7J2vYVpUozz6ribb/zjKb/8wmZZi7cXMxyc5XpbJ7rKVCFPFS168g0XBxQBoBlOw6N//6LRTuMhMGFdoX8wkFlIqKsCl+eotj9h7na/2jbcZr0N1fPknSo6oClzlw/a1qxD7hVYAyhcqowMESTubj8RZiruTY8SFnIez/Yj6IWzBHNmpdXq16JSVv3N7oIUTHleDNSKRxU9gwLX7mqOkjhs1RlyPHyxtzbGetUf1Sva68Py4E9fEkLX86D/OTDvRAO7JNP0uZmU7m/aX1lQ2EgKhsHlYmQfbAhb6fT9Q5f1RWdemVe1PjYeZ9crn08SzeZrvqqVPPqzPVFpJvpvEDl8mGwTicX4mNSS+pAmLPwrS7y6XR8S5uGpOdl401x16sBG+OUyFUcVCaCv52VTqp63jZjJyeddBe3jFvblPloPJ8ssZ+vg1W5seoiw8Jlswp1qRdn6Hq90SER2F8m21XxOjvtKVehPakCDipXSGshr2JFR5RWVWaT+3iWOpKulIsWHyPfQjZegJYRIp3HsC8Gq8fGfNxOXHjdOovi2Zau4fazIt0g79SYcERkuUbbx+rKbRxUdhALnT3y3ltjWlI7Rd+9dXNWYHOhSVOGrCtvtoXHc9alv4OKvsnGl7pF8ynr2pDCNtUFnKVFOjXdDDAXDKoQm+pTU5pfztfyNwPxY9tNyqz8OItq4KCyQ3Rfa/HajWgydo78oSMpS8kPrItLV5UnEHQp6wKFRYHIPr4MUKThww0u15u58A2XqDzIGzJkIz4hQFWUe1BZRLpFZKmI3KIjQEQmsPpPxodONlEarBuKYSJeWX2RD3y5XuWNHXclqUvdTN6JQPvQXHBwyx82JiX7VNFsTCubNW4OMdrcpmOm8qcBrNWwHyoZK70JVY2LKs4+cQk7bJ0xjtzG5CPyXEs3g3W2G8L9w9Y+MtPQDa5f21Qhn7meRmVKG1d545Y3Ps1jErgj16CyiJwF4K0ArtYTHKJqYV1JJvneYdfyoj72aIjGsTiYxzQgE8LdBeZBIiIiasg7U/k/AHwGQC1/UKiTJJ24hzb0Fh8QmuD7qJwFBobHjB6/7GuncDkvOne5eGFowwswSJ+qJ59rNy2SPN0yPFrDJ3+6BJt7jybbZygO3IoNSiIuTZdsP1RmMJpY+ZSWxiAdOj6Mv/jJIhw6PqxtnxbGmLcOHx/Rs58BPfsJCzdZuw4NxP6tyOOSXVzrx+i0Yuch/P0vlrf0Y1peKF52oGC2vKQ9dmMoJSofWdlWU6TMg8oi8jYA+5RSizt87yIRWSQii3p7OeCpQ7txzIVbDsRvl2I/VA7X2mETWeauNXsNHNUORWePcP578TPnFHy08tneGbE9fFXxkVfPMx0EryzdfhC3rNiDi29YmXrbKd3smFC1FNEX/+EjW3H3mqdwzaNbM++j3Q3cSlw/GDzH/1m4Tct+jg6NatlPnK/cytUv83K5H8gXJQIfveYJ3LBkJ/qOTtzAc+3ankiHPDOVXw3gHSKyFcB1AP5IRP6n9UtKqauUUvOVUvPnzp2b43CkGyu9MEYGVVt3Ja4S02PNUIwiZ7a89Ow5qb4/79RZxQTEI43kSpJsXV31uoQviSqGa4MQVZ7FZhqjPp3mJ8XYJ+qk6LqoUwq4VhfmUZ0z1Sdv/kiydeMF9uHvMq0mYz/Af5kHlZVSn1VKnaWUmgfgfQDuU0p9QFvIKFbWcsniHK+qdV1Vz9sVRadPeBzZ1THlduFm/rafDdmOnd3kEg0qB4nKQWV9GJX+05nEuuvVLPmPWZaoM9btbhvv79SYkFk12quoGGT5cEfeNZWpRK4O+hBRNlWahUFExSi7U96YuZPpGotVHpF2+m+c8YKEisfrXgqzcQJAl0Q8mWVfMIkK16NjJ0qpBwA8oGNfRC7J29/hoGFnFvYhyKDW7NAuf0z6ro4DkhfY/88mSZvVuMiy8QLQB+5Hq/mRIvfjsL3xFx/l2Efz49yeR5hHyqx3TZcjLlFiB1trh7z5I0n+bhyh1tSnbHlRn4GCYmuakL84U5nIINMdMurMpTfoUntZOnZMgmIUGa9x+w5fYNgySGJHKPSaWP7CbDjIDswGydg+PFaFWaPsc6VT+BJt1peK/JJGIW/STjwFlVQZ/TyJuInOpEoXAWnTlezEQWUi8KLHZmUP/pjuuJV59KY1lX3svLNnRyFxdQmzSWepXtQX9TgoEbWld03lxlRlPXtt3U2SMQDXiz/HOTqz5eYskSmsJ/Rxvc2oOg4qE8H8QGLZGudbrbN2T8WyZSZFd+iKrBuYvrB/ep4HdF74J3sbev3fpDOVWQw682nwhhfhzRgddjKZLlW7JokTrisYJfZxvV3Skad4Ez0ZRo//OKhMlAMvjopX5YbI9Q4bkU3iZuOzlOnViGcOjBCZoWVN5fDj3PmC4yST5+zK0kGs4vNjO+m2qOW+mKJURRxUdhAHmvSr6no+ac+6otFEFkvzor5M+9ewj05YrPTiNVozrUvbJFn+IuhZMh30aXqxJOPVS74NLvFaJbs8WaHobFTmS255zUG2k4iZylWftZz99Cdv6Fu76DMOKhPlkPvNsprC4TOb25OiG7tSX4LiSOfd5vxAyZlIx/AgR/MgHTOVTnkeB2VK+M+RpqY0RQycNXapq2prrSN9TUNbBsJtCUcnpptOV+JJp+4uX0tfZ2n7amXkT911rS62hYf8x0Flh+QewGQFEyvroEIVOzS+a01RprC7WOe5QymFe9Y8hTEDz/0eGRgp/ZgNruXRJG1e45r3wLHhgkND5D5b64DWYIWvQJIMhHv58t+SuLL8RZl8vd5Ke1YVHlO20vg7JEKF9tBxc31K39jaPtJkHFSuMF8b6CyyxoTrlZ0Lwbc5jF4tm2JzRLdR/Iv6it0/4GzUa9FIvttW7sXHf7IIP1ywJfc+4+IzbpCjp5tdoaSSlIeeYP2LLl79FoJ9N+pkYk3l+LySetZfyjC4nk+ndBusv5y5uCh8AYyC9++ekTFX8oZ5eWMqSR12eGAUADA8Vhv/bEvfsZxHriZnqj2KxCupCvFp/MsWVYtTF2eeFPloexGx0fRyHDawuehI+1IujJnO2Nc/CADYefB46cee2uN3V6jswZ3G47lTOVhPmNyOeXUztiJsa6Jecvacwo9x4owphR8jjiszlU33UV28Jslr9rQe00GgkNNmTwXAdi0sKiocqdIoB/b4iUwy3SNzgM3rndobsmSaGn5H+0Npsodt6aVa/q2yxjq8JuLC4irGOowqMxjvetkUn4WsqdyoT9u9yNamSLCQyQHLPDcCy0xWvqgvv7Tl0Mo4YV3SVtXqWp3nW7GocxoHlR2ie7ZRFe/wxjFV4bOyLJ7LjXnRMwxdjJtOcdI003vS3zIcz8E4ckNzxDZWSijrrdmq6XcmchGS3hBkGUuH8eWnstO10+GaX2ZaaFCsET5Pk4N3rsxUblVkW1qVPBincf68ck+uU1x1ylOp8pxlGdRkvzbtkSeWayKXcVC5wnghnR8H5qlIlvVRrGTlrA1KbPyRweBfLRfTLDiFSTJQzOindlhlu68KfV+TS8KXdXPVdh0HBSt4HVvlZRbSr+tevCqnRxlYFbqDg8pkDZPLHGQ9svNtiQ+PXWnGBswfrqSlzUu8lKVxAW8iKsxGvxtrdjfyKHMqpcU8056pAdpU7c6kdbH1hsVGRgfOWWiqg9dhxuiMSxZZqjoOKhPlwLGg4uV/e6+7ylyvjv3UaGWUcZfzqC4TF/CMDV9kSUm2qZ0xivxS6JIBGvdVtT6C2eUv3CjlRd8Q75QGVZgxT3Yb77m6UWStxBslfuCgskPYeBJVC2ewduZDFPlwDnmNr6lcK//Y3pcznbNx0kxu9DxaKRsbLiC9L/MJdIyB8JrKGYanXY9ik9k0T9wVHe/hvOB4EjvJgupzEl/zQaolldt8u2rLtETVQVmXTqta3LmMg8oV4noHr0imLjCYJgnkjCPXLh7dCq19ml4uZC4YqVSx09RaLBsDTTpmaCXZQ9MLHasX/Znpusii7Fxr06i9IiaMiMHlhMpQ1HmFd2tyrVRXkq3o/BUuG1GH8qGNSXoOje9xDd/kyqj/fK9riZLKPKgsIs8UkftFZI2IrBaRT+sMGBFR1bGPMlncYGRxxyvybeZM4Yn39NV/YYwQTeZyXeFy2H3GZGmPy1+QjTikbBdrx/gdqkL4JL4fenJsOwrg75VSS0TkBACLReRupdQaTWEjsl7exsSHu+xFKzuOqpom1naMcuBghju6ggxY5MV03GO7zCWdjcdRivRh8aMovICMpnf948ZNuux7baovK1iWTeZTV+K7zPd++MqVtLYB48oNWcttVa+/fZF5prJSao9Saknwez+AtQDO1BUwIipeFSrwIs+w6EFLdqDMKyMJmM6h2TcG4sL7+Dd0fr5HqymMV9KhCv2/PLoMDmi6ckPcdDh5g4qKlOodEsUFg8gJWtZUFpF5AF4CYKGO/VE1OdKHapKlO2O6E+Ya09FlNr2YVzppTZ52MWYyLdsdu4qpHHfONy7dhUc39eXbd8zO4y5ATQ6umK7f0kq0XnXK+HQsCiglG9PXpjAVMRtzfJ+aTrR1N90mR1wLFK6PT5wxxVg4Zk7L/iCxDzcL/vyHj+O5//e2phY7qg/lw7km1Tj9/ceGzQYkgqvXtTqCvWrXEQDA4q0HCz1OHmedPKPU46U933ZtoOm4o+RyDyqLyGwANwD4G6XUkYi/XyQii0RkUW9vb97DEVjAisA49RfTlqzHPIqZU7vHf79j9d5CjhF3Aco6IrlUM3cYr9o4HZVOB748ZZeXPMc7YXrnAVfXk/3cp802duyXzzvZ2LFt8NCGXozWXM9ByVTjLN2U5obf41sPFBeQnP7ydeeYDkLCF2gXHgwqUK5BZRGZgvqA8rVKqRujvqOUukopNV8pNX/u3Ll5Dld5VVhbqmpYgXZW5Sgq/M3aoUrFlccI07yoL80s5qT7yKrdfqo026ZVI/nC6Vj64Eq5hyudwXnYGbbwPTXyY7+BOtExUTmcz1ydiegqV/tjugkvfIkyCRfNnpKfLNHZXrDlcUfmQWWp1/Q/ALBWKXWZviAREZmTpi0sosPbdCGnfe9EdgqXJQ4s2qdRLzFtiIrB8TNyjen2wJXBd9Kj7DqS99KIksszU/nVAD4I4I9EZFnw8xZN4aISsLKcUGbHyKZBQxfyQN4wmu70UrFSzQDOkBV05Z+ovTBnTmheOzHfvuLSLPYC1IWK0EGMVo08iksbBk99z5uNONY1Y8zz6LJOnn5H0Xm7eQZ7scdqOm55hyqVD08B2HsGdoTMgyROJe3pWtAlIA0yvwlAKbUAzAdElWLDxWCVVK0jooPuDnoZaVDFdJ68jEl4pnJBxwzv2aKbey7h29BtwJj1kUtrKttxAP04CcEtVUovB4uTdowDv0WmLxPdGblf1EfuaG18bRsgNFltZK2zbItDH+XtNOaf9dhu3243duHsW4m8bPAc2+UVt3ORHjpnKqdlshi7lvbpXtTn2tkR+aHxVEaeIhjeVKmK9BEs4UrV6Uo4ibJhBteFdYX/OKhMlANfIkFF4qBMZ2le1GerKqdzow5tTsdi4iO8/EXTgAkvHArBWCWyV556jz1fAopvO6twicV2knyjs9iyfLiDg8oO0T3uUOFxDGswDexjU5IU/nRqwfsvQtkDgGUczcV00E3nxWPaepX1cGeNcpckqtLHPxMgDdeiizdtknEpntwJqZtcK+MNRYbb1Tghc2zKM+W/ZNCik0/IpTaQJuOgMhGq+7KJ1IvpV2HaQAqMD/Pav6iv0wflsanc24hvcXdD0RcqDl4HkZOY0TqVtXBZ58W+XaqynBb7BW5gu91e1epPnWfLvOUODio7hONX9sl7ge1aQ2Pizmf1GpTQhVzB5+7jmsq6o6yMmTfVy+MRdV8o/5XzcsTwgInfTM1YqWK+LoPr0epLW2OzRhy7nldKZ0mEWRKMjljH55c0DhnV5dOZv9nsxeMELT9wULnCWIYnuDa4S8m53OllvszHprS3KSw26go1SFV6UZ/PXHz80lZsC0i3VDkqQ/ZjjqW8eJ1KYWnbQZvyDwdOO4vqMjLa3MFB5Qqz7XrPxQvQvI0EH+3qzHiuaLe8goN51jfscLhNWv4F8g+gpV7T12At43MV4vGpUQo+53HbMe7d5ErfstRQRg048RqK2rCpGFU9p37uppU4OjSaejub0pDa46AykUGcfURtMXtMkqaDoad86UkElvXkSu9EMmkSS5U2jNdC8CKLdOg0cKlifid3/OnvnV3sAUpcos1X7BtSEWzrJ/xy8U58/6HNkX+rQjmvAg4qE6HkF/WFD2a40k87G8LI4zslr1ttW0NcpHByujrjI90gc7H7p+zCebGMKA/XZb4nsZZbK431v1Pszfd4pWxsaGtsrNe1rt8Z1G8csHJTp1Rrm1dCfzz39NlawhN7KOYvQrn54PQTppV2LF1npVS1nqqMq59qGRo51jHu4KBylbBcxmLUkI2YL9NrumejWv/GZQ5s0RofZa+p7MrjxTpU6FqGiBJK9dBBRarLipymMzoNxFVpwKlKfZZ2XB2cteFmalniymWWQWVyBweVHcQiSVVS5fzO9rezNB3MLDPtmQTFaiSJ1jWVOxyr9Tu8WEsuSVQ1vsJ41af5Zplb8epYcL3QqOraxT3TxV6upE2pT3n62hvz9LSKkurpxA7fLTXqqzOmHKsW2zkvNRhUEA4qE5HXiuz0FrEciCsXE5SftxdJWZTQqYwrWyxz9mBS+M/VmWZV07xSG0smTVZ0rjCy5B4R5RI3KzvT8hdsepzBQWWyRhXrDdfO2UT3znSDYvJiquhjhxt+9t3JpKZOaMlFzmQV49ys04K+S+05lk3IsETtecF5ink2Dzciz7X2y0aMwRQcjixeYqFj+rE6cRsHlYmAzA1VloE4mx67rkL9neW1AIm/WXD6sYHtbNK6yW3SL0t6mS6jvmqN1bJf1Ndu7W2aLMuSFozXYjBa82McpleFNUFdae/bvqevtFAUz/8cl5zN6VruMijuMRFmo5MlNK6p7GJ6VxUHlSuMBXUCH+2zlyudfLKPTXnHoqBYqWlN5ZyRFbd9VWfjM+uRSa39KxvKoe/18cSaym1usnaoGcJ/zxJfNqSzq1zJn2UG05U4IYrC+jB+TWVGjR84qEyUQxVmbpA57EN3VnRHjWlQtHoChtdOLCrOY9dUZionlm75C8ZrETi4Qi5gPvWf6TT24RrMdBxSPJ0TU3zIq3l1mqnMPqPbcg0qi8gFIrJeRDaJyMW6AkVEdjJxpzVvE1PkbFXXXyLiePA70pH0urIPO0vJlX2RxYu6YjBeicxo9E3aLpOQonyyKJfLlfguPJye91EpPVf7Fb5fbyWRJe1cTe8qyjyoLCLdAP4TwJsBnAfg/SJynq6AERFVnU3LNxCVpahcz069BhyIopw4Y4uIiKha4pemY5/ABz05tj0fwCal1GYAEJHrALwTwBodAfPJlr5jWLr9YO793LZyDwCgt38INy7ZGfu9uL8dGRhp+v8jm/qw/+hQqn0U6aalu9DTlaxi0R2+JdsPpd7njUt24sEN+1KHaTS0qNDibQeNxPXgSA1A/Q5gmuMfPD6Rh6K2K+JcFmzsw0kzpmTe/ubluzFjSnfi7zfipmHlrsOx53V0aHT8d13nvqXv2Pjvj2zqw4Fjw1r2G2XZjkPjvz+8sS/VOZjItwCw8+BA0/+XbGsuu6NjE+Vr9e4jTX87Njw2aX+dzuPwwIiWc/31st2Y1tN8H7e1Tk4aJh8sCdrEvqP19mxz70S+X7z1QK68GJdmy0P5ffuB4+O/b9p3NPHxdKfNk71HC90/ADy+JV18RhkMys6RwdGO++rtr/crhkdriY67Yufh8d9vWrITZ8yZkSOkfnpi64Hx3x/a2Is9hwfafNsuy3c0t6HhOtxUXXfn6r1Yvftw5y+WoJH/1+45oi0+FmzqAzBR9sciFrO8ZcVuzJoWfxkYbp9uX7mnqZw+uqkP806d2TYMy3Y0t80607p137qE24WbluzC3sOD2o+RxMLN+zE4Mrm/0nDjkp3ojrleWrunf/z3m5buStV/ThKn962buO5Z3pIO4WuENPuMs2rXRJ6Lyq/hPJn3WJ0U1Ue4beUezJnZOY2WbGs/jlDWNVl4v40+9VDCtj6ve9buQ1/MuEWU8DVOlPvW7UP/YHQ/HKjn57jzSnO+fUeHJt1K1bHfdjbum+hb3rhkF6Z0F7PibVR41+45Evnd326O7otuCsJ637p94783LN1e/DhJ2v2/6pzT8PSTphcUGndJ1plwInIhgAuUUh8P/v9BAL+nlPpky/cuAnARAJx99tkv27ZtW74QO+i6x7fj4htXmg4GESV09ikzmy4uyD7PPX32pM4HERERUVYnTOtBf2jCgItOnN6D0ZrC8Ygb6eSuqd1dGB6rdf4iWed3zzoJK3Yd5nIOHvjRh1+OP3zB6aaDYYSILFZKzY/6W56Zyokopa4CcBUAzJ8/v5JF6a0vegZeec6pib8/VlM4Y84MHDw+jNnTejA6pnB4YAQi9buBrbPdgPrnR4dGMXtaT+TfG44OjWLOzKkYHq0h6ia3UsDwWPQxdFGqftduak8Xpk/pxvBovYE8YXrn7DhWUxitqdzhG6spzJjajVNmTcXm3mOYOTXZTNaxmsLAyBhmTu0Zj7/e/iGcOGNKqjB1ieD48BimTzH3rsyh0RqmdnelfiS8f3AUM6d2j8+SqKn6jJaTZkzR+nj54EgNNaUSp02rmgKODY0myldhAsFZJ8/AniODGBoZi50N0jAwMoZpPd2R5SmrGVO7IRAcHy7+wmZaTzcU1Hg5bGdgZAyjYyp1nOo2fUo35s6ehp0HByLXKu7uEpw4YwoORszynj2tB7sPDWLmtG6MdahLRsZqhd3dbxitKfR0CYZHaxitKUyfojcv2Wz6lO6m2Vhp6veRYEZ6d5eMx9fImMLTT5oe+wRO4ztTuusbzJjSjVnTejrOfBkarWHGlG6M1lQhadMlgkPHR3DiDL3lqqaAgeExzJqWrQ4NEwieMWc6dh9KNkN2rKY61p1hc2ZMxfGR0UT1UFUdPD6CU2ZOdWZ99rGawtSershZsgMjY5je0136kjRK1fswustaXt1dEhlPebReLzT6KrOmdmOkpjCaYHBqtKYwtbtr/AVLPUF72G7bwZEapnTLePnPcl2hFHDSjCk4NjyK0TGF/ceGcOqsaRitKcydPQ2HBop7guv0E6ajf2gEAyUPyCpVf8rm1NlTY/NCu7jsEhlvo06eNRWqhsTxNFpTUArjbWOUxvXP7Gk96O4SHBkYjWxbagqYe8I0bO07hulTujL1oZSq97+m9nRBIBgcHYvNP8eGxqBQ7zcU0V8bGauhS2RSezYypnB0aBRnn1Kfsb92zxGcOWdG4jptWk+9/5OmDjxx+hTMnt6DbfuPYXCkhhOm92BwpJ4fwvsZHq33XXXXr8OjNfR0dzX1g7JeSyY91shYbXwwvZEHukTG67exmsLgaL09OWPODGzuO4qerq7xvKxUfSmu48Oj6BIZ72PHjacA9f7OSK0W+fR0OG+Gwzq1pwuzp/Xg8MAIukQwe3oPjg2NQqn60mvPOGkGjgyOYO/hQcya1jOpLzkyVkN3V5fWPuZJM6ZgrKaanqrVQSkEYyHxfcuRsfq1zYkzpmBf/yC6RNq2Aa19xrGaGu9DFKFxvEbapTH3hGmFhMl1eWYqvxLAJUqpNwX//ywAKKW+GrfN/Pnz1aJFizIdj4iIiIiIiIiIiIjK0W6mcp7h/ycAnCsizxaRqQDeB+DmHPsjIiIiIiIiIiIiIstlfv5LKTUqIp8EcCeAbgA/VEqt1hYyIiIiIiIiIiIiIrJOrkXFlFK3AbhNU1iIiIiIiIiIiIiIyHLm3hJGRERERERERERERM7hoDIRERERERERERERJSZKqfIOJtILYFtpB7TLaQD6TAeCiDJh+SVyE8sukZtYdoncxLJL5C6WX4rzLKXU3Kg/lDqoXGUiskgpNd90OIgoPZZfIjex7BK5iWWXyE0su0TuYvmlLLj8BRERERERERERERElxkFlIiIiIiIiIiIiIkqMg8rlucp0AIgoM5ZfIjex7BK5iWWXyE0su0TuYvml1LimMhERERERERERERElxpnKRERERERERERERJSYtYPKIvJMEblfRNaIyGoR+XTob6eIyN0isjH49+Tg8z8TkRUislJEHhWR3w1t80MR2Sciqzoc9wIRWS8im0Tk4tDnfyQiS0RklYj8WER6Yrb/gYgsD8JxvYjMDj6fJiI/D/a7UETmRWz7YhF5LDjfFSLyJ6G/XRuEa1VwLlNijn+HiBwSkVtaPk+6/YeCeN0oIh8Kff6yIF43ici3RUTaxSNVl8GyG/m9uGNGbP/JIH8rETkt4u8vF5FREbkw5Tl/KTi3ZSJyl4icEbH9s4L6ZVmw/SdCf/s3EdkhIkc7nP9ng/CvF5E3hT6PrNOIWjlcdiPbNxE5SUR+I/U2ebWIfCTlOf/v4LOaiES+CbvD9peKyLogfm4SkTkx+4jrdzxb6v2FTVLvP0xtF49UXRaW3Y5lp933ROTU4HyOisgVbbaPbLeTlP2W/dwcPgcRuUREdgVt8jIReUvMdiy7lJvD5TeyjROReSIyECo/V8Zsn6v8Sv2at/GdK0Wku12cRWzPa17KxcKym7TfGRe2k4PtVojI4yLywpjtI69NReTDItIbKvsfj9n+gaDtbHzv9ODzjuNlwffY9tpGKWXlD4BnAHhp8PsJADYAOC/4/zcAXBz8fjGArwe/vwrAycHvbwawMLS/PwDwUgCr2hyzG8CTAJ4DYCqA5QDOQ33wfQeA5wXf+yKAj8Xs48TQ75eFwvlXAK4Mfn8fgJ9HbPs8AOcGv58BYA+AOcH/3wJAgp+fAfjLmOO/HsDbAdzS8nnH7QGcAmBz8O/Jwe+N+HwcwCuC7W8H8GbTeYQ/dv6YKLvtvhd3zIjtXwJgHoCtAE5r+Vs3gPsA3AbgwpTnHK4TPtWoB1q2nwpgWvD77CAMZwT/f0Ww/6Ntzv28oL6aBuDZqNdj3Yip00znEf7Y+eNw2Y1s3wD831A45wI4AGBqinP+XwCeD+ABAPMzxNkbAfQEv389KvztyiiAXwB4X/D7lYhp9/nDHwvLbsey0+57AGYB+H0AnwBwRZvtI9vtJGU/9N33APhp+BwAXALgHzqcO8suf7T8OFx+I9u4oEy2PXbwvVzlF0H/GvW2/4ZQmevYdwCvefmj4cfCstux39khbJcC+ELw+wsA3BuzfeS1KYAPo02bHfpeZN2CZONlbHst/LF2prJSao9Saknwez+AtQDODP78TgA/Dn7/MYB3Bd97VCl1MPj8twDOCu3vIdQbpXbOB7BJKbVZKTUM4LrgWKcCGFZKbQi+dzeA98aE+wgABHc1ZwBQEWG+HsDrW+98KqU2KKU2Br/vBrAP9cYUSqnbVAD1xu4sRFBK3QugP+LzJNu/CcDdSqkDQTzeDeACEXkG6g33b4Ptf4IgzolaGSq77b4XecyI7ZcqpbbG7P6vUe+w7ovZNvacG3VCYBYm6oTw9sNKqaHgv9MQeookKHd7YsLV8E4A1ymlhpRSWwBsQr0+i6vTiCZxuOzGtW8KwAlBWzs7OMZo0nNWSq1VSq3vEPZ229+llGocryluQiLLaBDmP0K9v9D2/IlsK7tJyk677ymljimlFgAY7LB9XLvdsewDgNSfJvw7AF/uFNYILLukhcPlN0kb1277XOU31L/uQX1wKeqaO6788ZqXcrOw7CYtk3Fl5DzUJ1FBKbUOwDwReVrEcZJcm2bRcbwMbHutZO2gclgw9f0lABYGHz0tlJH3ApiU2QF8DPW7i2mcifqM5IadwWd9AHpk4hGgCwE8s014fxSE6wUAvtO676CwH0Z9sDpuH+ej3kA+2fL5FAAfBHBH8P/5InJ1stPruH3c+Z8Z/N76OVFbJZbddpIcM5aInAng3QC+l/D789B8zuOPCQH4MwCfDz5rKrvBI1QrUC+DXw9uLLU7zjtE5IvBf9uV3ajPidpysey2tm8ArkB9xtVuACsBfFopVWuz/Ty0lN2Y750hIrel3P6jCOKmZfu4MnoqgEOhiwOWXUrEkrJrWmzZF5Floe99CcC/AzgesY9PBo8A/zD0aDDLLhXK4fI73sYFni0iS0XkQRF5Tcp9JS2/EJE7UZ/w0Y+JwaTIOOM1LxXJwrLbWibD4sK2HPWndxpjUc9CyptFAN4rE8vAjo+XtZZdAD8Klr74l9DAceR4Gdte+1k/qBzMIrgBwN+0zPgDAAR3EVXLNn+IeiH9Jx1hCI7xPgDfEpHHUW+4xtp8/yOoL1+xFsCfxH0vTnCX9L8BfCTiAvi7AB5SSj0cHGuRUipyvZoYebcnSsSGspvkmAn8B4B/ajcY1RB3zkqpzymlngngWgCfDD5rKntKqR1KqRcBeC6AD0XdGW45l5uVUp9PeS5EHTlcdpvaN9RnIi1DvT1+MYArROTEqA07nXNLWHYrpZrWWG23vYh8DvVZVtfGbU+kg41l15DYsq+UejEAiMiLAZyjlLopYvvvATgn2HYP6gPPLLtUKFfLb2sbh3qZOVsp9RLUnwT4aVzbG6Nj+W1QSr0J9cfwp6E+SxEtfx+PM17zUlFsK7sRZTJWS9i+BmBOMAD81wCWos2YV4TfAJgXXM/ejYlZx61l98+UUr8D4DXBzwc7hJFtr+WsHlQOZh3dAOBapdSNoT89FQy8NgZg94W2eRGAqwG8Uym1v8P+nykTC4R/AsAuNM9APiv4DEqpx5RSr1FKnQ/gIdTXzIGI3Bls3zRbWCk1hvp0/MYyGeP7lvpL/k4CMCl8QaN5K4DPKaV+2/K3L6C+HMbftTuvNufbafu489+F5rtU4/FCFMVA2W0n8phxZTfCfADXichW1J9S+K6IvCsiTHHnHHYtYpbOaQhmKK9CvZFNql3ZjazTiKK4WnZj2rePALhR1W0CsAX1J4iSnnMi7bYXkQ8DeBvqHeioQfG4Mrof9Y59T8vnRJEsK7tx+2jMTJo001+zJGX/lQDmB237AgDPE5EHAEAp9ZRSaiy4mfx91B+3bcWyS9q4Wn6j2jhVX4ptf/D7YtSfun1eikMlarsblFKDAH6NieXdYuMshNe8pIVtZTeqTEaU3ciwKaWOKKU+EgwA/znq/erNHSMhoJTaryaWc7wawMtivtcYX+tH/Z0GjTY2yXgZ214LWTuoHEyD/wGAtUqpy1r+fDOADwW/fwj1hgQicjaAGwF8UE2sfxwrmBn44uDnSgBPADhX6m+OnIr67OSbg32Pv5US9TtKVwb7eFOw/cel7rmh8L8DwLqIMF8I4L7WC8zgmDcB+IlS6vqWv30c9Tu3708yY7JVwu3vBPBGqb/582TUF3u/U9UfjzgiIq8IzuvPEcQ5UStDZbedyGOGy26HYz1bKTVPKTUP9Ufr/kop9avwd9qds4icG/rvOzFRJ4S/c5aIzAh+Pxn1FxR1XM8u5GYA75P6W3OfDeBc1NeWja3TiFq5WnbbtG/bUX95LaQ+8//5aOkcdzjnjjqU/QsAfAbAO5RSUY/XAzFlNOgf3I96f6Hp/IlaWVh24/bxkWD7omccdSz7SqnvKaXOCNr23wewQSn1umCbZ4S++m7Ub/S2YtklLVwtv3FtnIjMFZHu4PfnoN4nTTwwhWRt9+zQoFgPgLci+po7rvzxmpdys63sxpXJiLY3LmxzgvYMAD6O+tN/bZ/eazl+uO18B+pP7bd+p0dETgt+n4L6AHijje04Xga2vXZSFrwtMOoH9Q6eArAC9UdglgF4S/C3UwHcC2AjgHsAnBJ8fjWAg6HvLwrt72eoP44zgvoaKx+LOe5bUJ+F/CTqs4Ubn1+KesFYj/qjDVHbdgF4BPX1n1ahPiux8Wba6QB+ifoLtB4H8JyI7T8QhG9Z6OfFwd9GgzA1Pv988Pl8AFeH9vEwgF4AA8F5vinl9h8NwrgJ9eU3EPreqmAfVwAQ03mEP3b+GCy7kd+LO2bE9p8KthtFfR23qyO+cw2AC1Oe8w1B2VmB+mNBZwafj5c9AH8c/H158O9FoX1/IwhXLfj3kuDzdwD4Yuh7nwvK53qE3lSNmDqNP/xp/XG47Ma1b2cAuAsTbfIHUp7zu4PwDAF4CvULzsZ+b0uw/SbU131rfH5l6/bB/+P6Hc9Bvb+wCfX+wzTTeYQ/dv5YWHYjy07E9rHfA7AV9RcRHQ2+c17E9pHtdruyD2BZxH7mAVgV+v9/B9uuQP0i9xmh/bLs8kfrj8PlN66Ney+A1cFnSwC8PWb7zOUX9TVgnwjibBXq7zDq6RBnvOblj9YfC8tuZJmM2D4ubK9EvU1bj/rA98kx28ddm341KPvLUR/gfUFom2XBv7MALA7ibDWAywF0B3+LHC8D217rfyRIACIiIiIiIiIiIiKijqxd/oKIiIiIiIiIiIiI7MNBZSIiIiIiIiIiIiJKjIPKRERERERERERERJQYB5WJiIiIiIiIiIiIKDEOKhMRERERERERERFRYhxUJiIiIqJKEpFLROQf2vz9XSJyXoL9NH1PRL4oIm/QFU4iIiIiIttwUJmIiIiIKNq7AHQcVG79nlLq80qpewoKExERERGRcRxUJiIiIqLKEJHPicgGEVkA4PnBZ38hIk+IyHIRuUFEZorIqwC8A8ClIrJMRM4Jfu4QkcUi8rCIvCDme9eIyIXBvreKyFeDvy0SkZeKyJ0i8qSIfCIUrn8MwrBCRP7VQNQQERERESXWYzoARERERERlEJGXAXgfgBej3g9eAmAxgBuVUt8PvvNlAB9TSn1HRG4GcItS6vrgb/cC+IRSaqOI/B6A7yql/ijie62H3q6UerGIfAvANQBeDWA6gFUArhSRNwI4F8D5AATAzSLyB0qph4qKCyIiIiKiPDioTERERERV8RoANymljgNAMBgMAC8MBpPnAJgN4M7WDUVkNoBXAfhlaNB4WsLjNo6zEsBspVQ/gH4RGRKROQDeGPwsDb43G/VBZg4qExEREZGVOKhMRERERFV3DYB3KaWWi8iHAbwu4jtdAA4ppV6cYf9Dwb+10O+N//egPjv5q0qp/8qwbyIiIiKi0nFNZSIiIiKqiocAvEtEZojICQDeHnx+AoA9IjIFwJ+Fvt8f/A1KqSMAtojI/wYAqfvd1u9ldCeAjwazoSEiZ4rI6Tn2R0RERERUKA4qExEREVElKKWWAPg5gOUAbgfwRPCnfwGwEMAjANaFNrkOwD+KyFIROQf1AeePichyAKsBvDPme2nDdReAnwJ4TERWArge+QapiYiIiIgKJUop02EgIiIiIiIiIiIiIkdwpjIRERERERERERERJcZBZSIiIiIiIiIiIiJKjIPKRERERERERERERJQYB5WJiIiIiIiIiIiIKDEOKhMRERERERERERFRYhxUJiIiIiIiIiIiIqLEOKhMRERERERERERERIlxUJmIiIiIiIiIiIiIEvt/8wU6jnikMQkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1800x216 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data3[\"target\"].plot(figsize=(25, 3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "b2ed3f57-27a2-41aa-9b10-fef8677b6a32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_date = \"2021-11-01 00:00\"\n",
+    "split_date = \"2021-12-01 00:00\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82b44f3e-2dc7-42d1-bd44-d29b47782aa5",
+   "metadata": {},
+   "source": [
+    "### Option 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "3a585293-247e-4d9d-97a4-3c32a4b82089",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data1_train = data1[start_date:split_date]\n",
+    "data1_train = data1_train.sample(frac=1)\n",
+    "data1_test = data1[split_date:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "aggressive-conviction",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "RandomForestClassifier(n_jobs=-1, oob_score=True, random_state=123456)"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rf1 = RandomForestClassifier(n_estimators=100, oob_score=True, random_state=123456, n_jobs=-1)\n",
+    "rf1.fit(data1_train[selected_features].values, data1_train[\"target\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "advanced-authentication",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out-of-bag score estimate: 0.982\n",
+      "Mean accuracy score: 0.96\n"
+     ]
+    }
+   ],
+   "source": [
+    "predicted = rf1.predict(data1_test[selected_features].values)\n",
+    "accuracy = accuracy_score(data1_test[\"target\"], predicted)\n",
+    "print(f'Out-of-bag score estimate: {rf1.oob_score_:.3}')\n",
+    "print(f'Mean accuracy score: {accuracy:.3}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "e5ad1baf-e55c-4651-bbb7-c7cd327656c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "652"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data1_test[\"target\"].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "0410a351-f2cc-45fd-a0b6-9617db72cf78",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "73"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "((predicted == 1) & (data1_test[\"target\"] == predicted)).sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "c691687a-cf1a-4803-922b-18f0425994ec",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "167"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "((predicted == 1) & (data1_test[\"target\"] != predicted)).sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "a5ce09ea-f5e6-4250-9e81-7f487437983d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "avg: 42910.17964071856\n",
+      "min: -121000.0\n",
+      "max: 98000.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "y1.loc[split_date:, \"predicted\"] = predicted\n",
+    "loss1 = y1.loc[data1_test[(data1_test[\"target\"] !=predicted) & (predicted==1)].index]\n",
+    "print('avg: {}'.format((loss1['close_t+120'] - loss1['close']).mean()))\n",
+    "print('min: {}'.format((loss1['close_t+120'] - loss1['close']).min()))\n",
+    "print('max: {}'.format((loss1['close_t+120'] - loss1['close']).max()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "33b0a1da-1a5d-4975-b6f6-b78d659b3892",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>close</th>\n",
+       "      <th>close_t+20</th>\n",
+       "      <th>close_t+60</th>\n",
+       "      <th>close_t+120</th>\n",
+       "      <th>earn+20</th>\n",
+       "      <th>earn+60</th>\n",
+       "      <th>earn+120</th>\n",
+       "      <th>target</th>\n",
+       "      <th>predicted</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>datetime</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2021-12-04 16:49:00</th>\n",
+       "      <td>4944000.0</td>\n",
+       "      <td>5031000.0</td>\n",
+       "      <td>5064000.0</td>\n",
+       "      <td>4954000.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-04 16:50:00</th>\n",
+       "      <td>4956000.0</td>\n",
+       "      <td>5029000.0</td>\n",
+       "      <td>5050000.0</td>\n",
+       "      <td>4925000.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-04 16:51:00</th>\n",
+       "      <td>4960000.0</td>\n",
+       "      <td>5033000.0</td>\n",
+       "      <td>5063000.0</td>\n",
+       "      <td>4948000.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-04 16:52:00</th>\n",
+       "      <td>4961000.0</td>\n",
+       "      <td>5030000.0</td>\n",
+       "      <td>5064000.0</td>\n",
+       "      <td>4948000.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-04 16:53:00</th>\n",
+       "      <td>4978000.0</td>\n",
+       "      <td>5032000.0</td>\n",
+       "      <td>5069000.0</td>\n",
+       "      <td>4959000.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-13 18:27:00</th>\n",
+       "      <td>4956000.0</td>\n",
+       "      <td>4956000.0</td>\n",
+       "      <td>4946000.0</td>\n",
+       "      <td>4965000.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-13 18:28:00</th>\n",
+       "      <td>4956000.0</td>\n",
+       "      <td>4956000.0</td>\n",
+       "      <td>4946000.0</td>\n",
+       "      <td>4964000.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-13 18:29:00</th>\n",
+       "      <td>4961000.0</td>\n",
+       "      <td>4958000.0</td>\n",
+       "      <td>4945000.0</td>\n",
+       "      <td>4962000.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-13 18:31:00</th>\n",
+       "      <td>4958000.0</td>\n",
+       "      <td>4964000.0</td>\n",
+       "      <td>4950000.0</td>\n",
+       "      <td>4965000.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-13 18:32:00</th>\n",
+       "      <td>4953000.0</td>\n",
+       "      <td>4963000.0</td>\n",
+       "      <td>4954000.0</td>\n",
+       "      <td>4971000.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>167 rows × 9 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         close  close_t+20  close_t+60  close_t+120  earn+20  \\\n",
+       "datetime                                                                       \n",
+       "2021-12-04 16:49:00  4944000.0   5031000.0   5064000.0    4954000.0        0   \n",
+       "2021-12-04 16:50:00  4956000.0   5029000.0   5050000.0    4925000.0        0   \n",
+       "2021-12-04 16:51:00  4960000.0   5033000.0   5063000.0    4948000.0        0   \n",
+       "2021-12-04 16:52:00  4961000.0   5030000.0   5064000.0    4948000.0        0   \n",
+       "2021-12-04 16:53:00  4978000.0   5032000.0   5069000.0    4959000.0        0   \n",
+       "...                        ...         ...         ...          ...      ...   \n",
+       "2021-12-13 18:27:00  4956000.0   4956000.0   4946000.0    4965000.0        0   \n",
+       "2021-12-13 18:28:00  4956000.0   4956000.0   4946000.0    4964000.0        0   \n",
+       "2021-12-13 18:29:00  4961000.0   4958000.0   4945000.0    4962000.0        0   \n",
+       "2021-12-13 18:31:00  4958000.0   4964000.0   4950000.0    4965000.0        0   \n",
+       "2021-12-13 18:32:00  4953000.0   4963000.0   4954000.0    4971000.0        0   \n",
+       "\n",
+       "                     earn+60  earn+120  target  predicted  \n",
+       "datetime                                                   \n",
+       "2021-12-04 16:49:00        1         0       0        1.0  \n",
+       "2021-12-04 16:50:00        0         0       0        1.0  \n",
+       "2021-12-04 16:51:00        1         0       0        1.0  \n",
+       "2021-12-04 16:52:00        1         0       0        1.0  \n",
+       "2021-12-04 16:53:00        0         0       0        1.0  \n",
+       "...                      ...       ...     ...        ...  \n",
+       "2021-12-13 18:27:00        0         0       0        1.0  \n",
+       "2021-12-13 18:28:00        0         0       0        1.0  \n",
+       "2021-12-13 18:29:00        0         0       0        1.0  \n",
+       "2021-12-13 18:31:00        0         0       0        1.0  \n",
+       "2021-12-13 18:32:00        0         0       0        1.0  \n",
+       "\n",
+       "[167 rows x 9 columns]"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "loss1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74739009-5b26-46ac-92e5-31d244534c07",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Option 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "f66c7652-0fd3-4782-8350-0b9e92190161",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data2_train = data2[start_date:split_date]\n",
+    "data2_train = data2_train.sample(frac=1)\n",
+    "data2_test = data2[split_date:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "0097d370-059a-40f9-8c95-9b67799c7e56",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "RandomForestClassifier(n_jobs=-1, oob_score=True, random_state=123456)"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rf2 = RandomForestClassifier(n_estimators=100, oob_score=True, random_state=123456, n_jobs=-1)\n",
+    "rf2.fit(data2_train[selected_features].values, data2_train[\"target\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "c7bdffa4-fdd7-46a5-be9d-ae85a50c57c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out-of-bag score estimate: 0.966\n",
+      "Mean accuracy score: 0.925\n"
+     ]
+    }
+   ],
+   "source": [
+    "predicted = rf2.predict(data2_test[selected_features].values)\n",
+    "accuracy = accuracy_score(data2_test[\"target\"], predicted)\n",
+    "print(f'Out-of-bag score estimate: {rf2.oob_score_:.3}')\n",
+    "print(f'Mean accuracy score: {accuracy:.3}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "d40607e2-97d4-4494-bb05-f3132ec9b089",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1430"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data2_test[\"target\"].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "3678a31f-721d-41bb-bbda-fc6ed9aa651c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "279"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "((predicted == 1) & (data2_test[\"target\"] == predicted)).sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "145eac11-1e6f-4cfe-83be-b63df1d33d5c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "231"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "((predicted == 1) & (data2_test[\"target\"] != predicted)).sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "7858f59c-c985-40ff-8f6a-82316f198f01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y2.loc[split_date:, \"predicted\"] = predicted\n",
+    "loss2 = y2.loc[data2_test[(data2_test[\"target\"] !=predicted) & (predicted==1)].index]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "1e8cfea9-5c52-4004-a819-fd31294fbbfa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>close</th>\n",
+       "      <th>max_in_wind</th>\n",
+       "      <th>max_earn_in_wind</th>\n",
+       "      <th>target</th>\n",
+       "      <th>clost_t+120</th>\n",
+       "      <th>predicted</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>datetime</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2021-12-04 14:04:00</th>\n",
+       "      <td>5075000.0</td>\n",
+       "      <td>5122000.0</td>\n",
+       "      <td>0.009261</td>\n",
+       "      <td>0</td>\n",
+       "      <td>5003000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-04 14:05:00</th>\n",
+       "      <td>5088000.0</td>\n",
+       "      <td>5122000.0</td>\n",
+       "      <td>0.006682</td>\n",
+       "      <td>0</td>\n",
+       "      <td>5000000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-04 14:06:00</th>\n",
+       "      <td>5083000.0</td>\n",
+       "      <td>5122000.0</td>\n",
+       "      <td>0.007673</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4977000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-04 14:07:00</th>\n",
+       "      <td>5041000.0</td>\n",
+       "      <td>5122000.0</td>\n",
+       "      <td>0.016068</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4957000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-04 14:09:00</th>\n",
+       "      <td>5035000.0</td>\n",
+       "      <td>5122000.0</td>\n",
+       "      <td>0.017279</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4940000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-13 18:28:00</th>\n",
+       "      <td>4956000.0</td>\n",
+       "      <td>4971000.0</td>\n",
+       "      <td>0.003027</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4964000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-13 18:29:00</th>\n",
+       "      <td>4961000.0</td>\n",
+       "      <td>4971000.0</td>\n",
+       "      <td>0.002016</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4962000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-13 19:07:00</th>\n",
+       "      <td>4955000.0</td>\n",
+       "      <td>4974000.0</td>\n",
+       "      <td>0.003835</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4974000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-13 19:08:00</th>\n",
+       "      <td>4957000.0</td>\n",
+       "      <td>4975000.0</td>\n",
+       "      <td>0.003631</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4975000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-12-13 19:23:00</th>\n",
+       "      <td>4947000.0</td>\n",
+       "      <td>4993000.0</td>\n",
+       "      <td>0.009299</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4993000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>231 rows × 6 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         close  max_in_wind  max_earn_in_wind  target  \\\n",
+       "datetime                                                                \n",
+       "2021-12-04 14:04:00  5075000.0    5122000.0          0.009261       0   \n",
+       "2021-12-04 14:05:00  5088000.0    5122000.0          0.006682       0   \n",
+       "2021-12-04 14:06:00  5083000.0    5122000.0          0.007673       0   \n",
+       "2021-12-04 14:07:00  5041000.0    5122000.0          0.016068       0   \n",
+       "2021-12-04 14:09:00  5035000.0    5122000.0          0.017279       0   \n",
+       "...                        ...          ...               ...     ...   \n",
+       "2021-12-13 18:28:00  4956000.0    4971000.0          0.003027       0   \n",
+       "2021-12-13 18:29:00  4961000.0    4971000.0          0.002016       0   \n",
+       "2021-12-13 19:07:00  4955000.0    4974000.0          0.003835       0   \n",
+       "2021-12-13 19:08:00  4957000.0    4975000.0          0.003631       0   \n",
+       "2021-12-13 19:23:00  4947000.0    4993000.0          0.009299       0   \n",
+       "\n",
+       "                     clost_t+120  predicted  \n",
+       "datetime                                     \n",
+       "2021-12-04 14:04:00    5003000.0        1.0  \n",
+       "2021-12-04 14:05:00    5000000.0        1.0  \n",
+       "2021-12-04 14:06:00    4977000.0        1.0  \n",
+       "2021-12-04 14:07:00    4957000.0        1.0  \n",
+       "2021-12-04 14:09:00    4940000.0        1.0  \n",
+       "...                          ...        ...  \n",
+       "2021-12-13 18:28:00    4964000.0        1.0  \n",
+       "2021-12-13 18:29:00    4962000.0        1.0  \n",
+       "2021-12-13 19:07:00    4974000.0        1.0  \n",
+       "2021-12-13 19:08:00    4975000.0        1.0  \n",
+       "2021-12-13 19:23:00    4993000.0        1.0  \n",
+       "\n",
+       "[231 rows x 6 columns]"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "loss2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e037e532-9780-4c66-ba19-2a6bfb1efbfc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1ee6cb5-a11f-42d7-b606-a6283fccc04b",
+   "metadata": {},
+   "source": [
+    "## Playground..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3409671-0acd-48e8-b1da-470b1f5ed06b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# lightgbm 적용 - hyper-parameter 튜닝이 필요하다. \n",
+    "train_ds = lgb.Dataset(data1_train[selected_features].values, label=data1_train[\"target\"], feature_name=selected_features)\n",
+    "test_ds = lgb.Dataset(data1_test[selected_features].values, label=data1_test[\"target\"], feature_name=selected_features)\n",
+    "params = {\"learning_rate\": 0.001,\n",
+    "          \"max_depth\": 16,\n",
+    "          \"boosting\": \"gbdt\",\n",
+    "          \"objective\": \"binary\",\n",
+    "          \"metric\": \"binary_logloss\",\n",
+    "          \"is_training_metric\": True,\n",
+    "          \"num_leaves\": 144,\n",
+    "          \"feature_fraction\":0.9,\n",
+    "          \"bagging_fraction\": 0.7,\n",
+    "          \"bagging_freq\": 5,\n",
+    "          \"seed\": 123456}\n",
+    "\n",
+    "model = lgb.train(params, train_ds, 1000, test_ds, verbose_eval=100, early_stopping_rounds=100)\n",
+    "predicted = model.predict(data1_test[selected_features])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 304,
+   "id": "0ddf3073-e2d2-4e76-a1ee-153d16a553fc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 304,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(predicted >= 0.5).astype(int).sum()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
  - Labeling 방법 추가해보았습니다. 120 분 이내에 목표 수익률 이상 나오는 시점을 1로 labeling 하는 방법 
  - train과 validation 데이터 split 시 random이 아닌 time 기반으로 분리해서 검증을 진행해보았습니다. 
  - 좀 더 테스트를 해봐야겠지만 특정 시점을 기준으로 validation 셋을 생성한 경우 성능이 좋지 않게 나오는거 같습니다.